### PR TITLE
Add community-health files and expand README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# For more information, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# Global code owner
+* @mnriem

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <opensource@github.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to the Spec Kit Copilot Plugin
+
+Hi there! We're thrilled that you'd like to contribute to the Spec Kit Copilot Plugin. Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## About this repository
+
+This repository is a [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli) **skills plugin**. It does not contain application code — it is a set of Markdown skill files that teach the Copilot agent how and when to drive the Spec Kit [`specify`](https://github.com/github/spec-kit) CLI. Its layout is:
+
+- `plugin.json` — the plugin manifest (required).
+- `skills/<name>/SKILL.md` — one skill per `specify` command group (YAML frontmatter + Markdown body).
+- `.github/plugin/marketplace.json` — the marketplace manifest used for distribution.
+- `AGENTS.md` — maintainer guidance and the design decisions behind the plugin. **Read this before adding, removing, or regenerating skills.**
+
+## Prerequisites
+
+1. Install the [GitHub Copilot CLI](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/about-copilot-cli).
+2. Install the Spec Kit `specify` CLI (used to enumerate the command surface the skills wrap):
+
+   ```bash
+   uv tool install specify-cli   # or: pipx install specify-cli
+   specify --version
+   ```
+
+## Making a change
+
+1. Fork and clone the repository.
+2. Create a new branch: `git checkout -b <type>/<short-slug>`.
+3. Make your change. When editing skills, keep the design decisions in [`AGENTS.md`](AGENTS.md) intact — in particular, the integration is always Copilot in skills mode, and there is intentionally no integration-management skill.
+4. Install the plugin locally and verify it loads with the expected skill count:
+
+   ```bash
+   copilot plugin install ./
+   copilot plugin list
+   ```
+
+5. Push to your fork and [submit a pull request](https://github.com/github/spec-kit-copilot/pulls).
+6. Wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Keep each `SKILL.md` focused on a single `specify` command group, with a discovery-oriented `description` (USE FOR / DO NOT USE FOR) and an accurate list of subcommands and options.
+- Keep the change as focused as possible. If there are multiple unrelated changes, submit them as separate pull requests.
+- Write a [good commit message](https://cbea.ms/git-commit/).
+- Update the README and `AGENTS.md` if your change affects behavior or the skill set.
+
+### Versioning
+
+This plugin tracks the `specify` CLI version in lockstep. When revving, bump `plugin.json` and both versions in `.github/plugin/marketplace.json` together to the targeted `specify` release, and update the README "Versioning" note. See [`AGENTS.md`](AGENTS.md) for the full checklist.
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ of focused **skills** — one per `specify` command group — so the agent knows
 how to drive the `specify` CLI on your behalf (scaffolding Copilot projects, managing
 extensions/presets/bundles, running workflows, and maintaining the CLI).
 
+**Status:** active development. This is a companion to the agent-agnostic
+[Spec Kit](https://github.com/github/spec-kit) project, focused on making the Copilot
+CLI and Copilot App integration smoother.
+
+## Background
+
+[Spec Kit](https://github.com/github/spec-kit) provides the `specify` CLI for
+Spec-Driven Development and is intentionally agent-agnostic. This repository delivers
+the **Copilot** companion: a skills plugin so Copilot CLI and Copilot App users get a
+first-class, guided experience driving `specify` without leaving the agent.
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started, and
+[open issues](https://github.com/github/spec-kit-copilot/issues) for the current roadmap.
+
 ## Skills
 
 | Skill | Wraps | Purpose |
@@ -111,3 +125,19 @@ spec-kit-copilot/
     ├── speckit-workflow-step/SKILL.md
     └── speckit-self/SKILL.md
 ```
+
+## License
+
+This project is licensed under the terms of the MIT open source license. Please refer to the [LICENSE](./LICENSE) file for the full terms.
+
+## Maintainers
+
+This project is maintained by GitHub staff. See [`.github/CODEOWNERS`](.github/CODEOWNERS) for the current owners.
+
+## Support
+
+See [SUPPORT.md](./SUPPORT.md) for how to get help and file issues. Please also review the [Code of Conduct](./CODE_OF_CONDUCT.md) and [Security Policy](./SECURITY.md).
+
+## Acknowledgement
+
+Built on top of [Spec Kit](https://github.com/github/spec-kit) and its `specify` CLI. Thanks to the Spec Kit team and community.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+Thanks for helping make GitHub safe for everyone.
+
+GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
+
+Even though [open source repositories are outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards, we will ensure that your finding gets passed along to the appropriate maintainers for remediation.
+
+## Reporting Security Issues
+
+If you believe you have found a security vulnerability in any GitHub-owned repository, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please send an email to opensource-security[@]github.com.
+
+Please include as much of the information listed below as you can to help us better understand and resolve the issue:
+
+- The type of issue (e.g., buffer overflow, SQL injection, or cross-site scripting)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Policy
+
+See [GitHub's Safe Harbor Policy](https://docs.github.com/en/site-policy/security-policies/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+# Support
+
+## How to get help
+
+Please search existing [issues](https://github.com/github/spec-kit-copilot/issues) before creating new ones to avoid duplicates.
+
+- Review the [README](./README.md) for installation and usage instructions
+- Review [CONTRIBUTING.md](./CONTRIBUTING.md) if you'd like to propose a change
+- Open a [GitHub issue](https://github.com/github/spec-kit-copilot/issues/new) for bug reports and feature requests
+- For questions about the underlying `specify` CLI and Spec-Driven Development itself, see the [Spec Kit](https://github.com/github/spec-kit) project
+
+## Project Status
+
+**Spec Kit Copilot Plugin** is under active development and maintained by GitHub staff and the community. We will do our best to respond to support, feature requests, and community questions as time permits.
+
+## GitHub Support Policy
+
+Support for this project is limited to the resources listed above.


### PR DESCRIPTION
Adds the standard open-source community-health files and rounds out the README, aligned with the sibling [`github/spec-kit`](https://github.com/github/spec-kit) repository.

## Added
- `LICENSE` — MIT
- `CODE_OF_CONDUCT.md` — Contributor Covenant 1.4
- `SECURITY.md` — security reporting policy
- `SUPPORT.md` — how to get help and file issues
- `CONTRIBUTING.md` — contribution guide tailored to this skills plugin
- `.github/CODEOWNERS`

## Updated
- `README.md` — added **Background**, **License**, **Maintainers**, **Support**, and **Acknowledgement** sections.

No functional changes to the plugin, skills, or manifests.