### PR TITLE
Fix speckit-init hang, de-pin CLI install, align version to 0.15.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Spec Kit plugins for GitHub Copilot CLI.",
-    "version": "0.11.8"
+    "version": "0.15.0"
   },
   "plugins": [
     {
       "name": "spec-kit-copilot",
       "description": "Exposes the Spec Kit (specify) CLI to GitHub Copilot CLI as skills for spec-driven development.",
-      "version": "0.11.8",
+      "version": "0.15.0",
       "source": "."
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,5 +79,10 @@ runs the CLI.
    the README "Versioning" note. Keep the `speckit-cli-setup` skill installing the
    **latest** `specify-cli` from PyPI (no `@vX.Y.Z` pin); only touch the `>= 0.11`
    minimum notes if the floor actually changes.
-4. Reinstall and verify: `copilot plugin install ./` then `copilot plugin list`
-   should report the new version with the expected skill count.
+4. Reinstall and verify. `copilot plugin install` takes a `plugin@marketplace`,
+   `owner/repo`, `owner/repo:path`, or git URL — it does **not** accept a local path.
+   After the change is pushed and the marketplace catalog is refreshed
+   (`copilot plugin marketplace update spec-kit-marketplace`), run
+   `copilot plugin install spec-kit-copilot@spec-kit-marketplace` (or
+   `copilot plugin update`) and confirm `copilot plugin list` reports the new version
+   with the expected skill count.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,14 +40,20 @@ runs the CLI.
 
    Every command-running skill carries a **Prerequisite** note that defers to
    `speckit-cli-setup` when `specify --version` fails. `speckit-cli-setup` installs the
-   tag matching the lockstep version (see decision 3) via `uv` (preferred) or `pipx`;
-   `speckit-self` handles upgrading an already-installed CLI. Keep this prerequisite
-   wiring when adding new skills.
+   **latest** `specify-cli` from PyPI via `uv` (preferred) or `pipx`; `speckit-self`
+   handles upgrading an already-installed CLI. Keep this prerequisite wiring when
+   adding new skills.
 
-3. **Versioning is lockstep with the Specify CLI.** The plugin `version` in
-   `plugin.json` and the versions in `.github/plugin/marketplace.json` track the
-   targeted `specify` release (e.g. plugin `0.11.8` targets `specify 0.11.8`). When
-   revving, bump all three together and update the README "Versioning" note.
+3. **The plugin is not pinned to a specific Specify CLI version.** It targets the
+   **latest** `specify` published on PyPI (package `specify-cli`), with a minimum floor
+   of **>= 0.11** for the `bundle` / `workflow step` skills — do **not** hard-pin an
+   `@vX.Y.Z` install tag in the skills. The plugin's own `version` in `plugin.json` and
+   `.github/plugin/marketplace.json` is an **independent** semver that tracks changes to
+   the plugin/skills themselves, not the CLI release. When revving the plugin, bump those
+   versions together and update the README "Versioning" note. Note: `specify init` stamps
+   whichever installed CLI version ran it into the generated project
+   (`.specify/init-options.json`, integration manifests), so the CLI version is
+   determined at init time, not by this plugin.
 
 4. **Skills are guidance, not dispatch.** SKILL.md frontmatter needs `name`
    (matching the directory), a discovery-oriented `description` (USE FOR / DO NOT
@@ -63,14 +69,15 @@ runs the CLI.
 
 ## When revving the plugin
 
-1. Re-enumerate the `specify` CLI surface for the targeted version
+1. Re-enumerate the `specify` CLI surface for the **latest** release
    (`specify <group> --help`, including nested `catalog` / `step` groups).
 2. Add/adjust skills for new or changed command groups — but keep decision (1):
    no integration-management skill, and `init` stays Copilot + skills mode
    (`--integration copilot --integration-options="--skills"`).
-3. Bump `plugin.json` + both versions in `.github/plugin/marketplace.json` to the
-   targeted `specify` version; update the README "Versioning" note; and update the
-   install tag (`@vX.Y.Z`) in the `speckit-cli-setup` skill plus the `>= 0.11` minimum
-   notes if the floor changes.
+3. Bump the plugin's own `version` in `plugin.json` + both versions in
+   `.github/plugin/marketplace.json` together (independent plugin semver), and update
+   the README "Versioning" note. Keep the `speckit-cli-setup` skill installing the
+   **latest** `specify-cli` from PyPI (no `@vX.Y.Z` pin); only touch the `>= 0.11`
+   minimum notes if the floor actually changes.
 4. Reinstall and verify: `copilot plugin install ./` then `copilot plugin list`
    should report the new version with the expected skill count.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 ### Versioning
 
-This plugin tracks the `specify` CLI version in lockstep. When revving, bump `plugin.json` and both versions in `.github/plugin/marketplace.json` together to the targeted `specify` release, and update the README "Versioning" note. See [`AGENTS.md`](AGENTS.md) for the full checklist.
+This plugin is **not** pinned to a specific `specify` CLI version — it targets the **latest** `specify-cli` published on PyPI, with a minimum floor of **>= 0.11** for the `bundle` / `workflow step` skills. The plugin's own `version` in `plugin.json` (and `.github/plugin/marketplace.json`) is an independent semver that tracks changes to the plugin/skills, not the CLI release. When revving, bump `plugin.json` and both `.github/plugin/marketplace.json` versions together, and update the README "Versioning" note. See [`AGENTS.md`](AGENTS.md) for the full checklist.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ sub-commands, options, and usage notes. The plugin is described by the
   specify --version
   ```
 
-> **Versioning:** this plugin tracks the Specify CLI version (lockstep). Plugin
-> `0.11.8` targets `specify 0.11.8`; install or upgrade the matching CLI with
-> `specify self upgrade`.
+> **Versioning:** this plugin is **not** pinned to a specific Specify CLI version.
+> It targets the **latest** `specify` published on PyPI (package `specify-cli`), with a
+> minimum floor of **>= 0.11** for the `bundle` / `workflow step` skills. Install or
+> upgrade with `uv tool install specify-cli` / `uv tool upgrade specify-cli` (or the
+> `pipx` equivalents), or `specify self upgrade`. The plugin's own `version` in
+> `plugin.json` is independent of the CLI version.
 
 ## Installation
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-kit-copilot",
   "description": "Spec Kit for GitHub Copilot CLI. Exposes the Specify CLI — part of GitHub Spec Kit, a toolkit for Spec-Driven Development (SDD) — to the Copilot agent as skills for scaffolding projects and managing extensions, presets, bundles, and workflows.",
-  "version": "0.11.8",
+  "version": "0.15.0",
   "author": {
     "name": "GitHub",
     "url": "https://github.com/github/spec-kit-copilot"

--- a/skills/speckit-cli-setup/SKILL.md
+++ b/skills/speckit-cli-setup/SKILL.md
@@ -38,8 +38,10 @@ uv tool install specify-cli
 # Alternative: pipx (persistent install, latest from PyPI)
 pipx install specify-cli
 
-# One-off / ephemeral (no install) — handy to bootstrap a project
-uvx --from specify-cli specify init . --integration copilot --integration-options="--skills"
+# One-off / ephemeral (no install) — handy to bootstrap a project.
+# Pass --script (py keeps this cross-platform) so the PTY-backed agent shell
+# doesn't hit the interactive "Choose script type" chooser and hang.
+uvx --from specify-cli specify init . --integration copilot --integration-options="--skills" --script py
 ```
 
 If neither `uv` nor `pipx` is available, tell the user to install `uv` first

--- a/skills/speckit-cli-setup/SKILL.md
+++ b/skills/speckit-cli-setup/SKILL.md
@@ -18,27 +18,28 @@ Always check availability before doing anything else:
 specify --version
 ```
 
-- **Prints a version (e.g. `specify 0.11.8`)** → the CLI is installed. If a skill needs
+- **Prints a version (e.g. `specify 0.15.0`)** → the CLI is installed. If a skill needs
   `bundle` or `workflow step`, ensure the version is **>= 0.11**; if it is older, hand
   off to the **speckit-self** skill to upgrade.
 - **`command not found` / non-zero exit** → not installed. Install it (below).
 
 ## Install
 
-Spec Kit's `specify` CLI is distributed from its Git repository. **[uv](https://docs.astral.sh/uv/)**
-is the recommended installer; **[pipx](https://pipx.pypa.io/)** is an alternative.
-This plugin targets `specify` **0.11.8** (see the README "Versioning" note), so install
-that tag (or a newer release):
+Spec Kit's `specify` CLI is published on PyPI as
+**[`specify-cli`](https://pypi.org/project/specify-cli/)**. Install the **latest**
+release — this plugin is not pinned to a specific `specify` version.
+**[uv](https://docs.astral.sh/uv/)** is the recommended installer;
+**[pipx](https://pipx.pypa.io/)** is an alternative:
 
 ```bash
-# Recommended: uv (persistent install)
-uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.11.8
+# Recommended: uv (persistent install, latest from PyPI)
+uv tool install specify-cli
 
-# Alternative: pipx (persistent install)
-pipx install "specify-cli @ git+https://github.com/github/spec-kit.git@v0.11.8"
+# Alternative: pipx (persistent install, latest from PyPI)
+pipx install specify-cli
 
 # One-off / ephemeral (no install) — handy to bootstrap a project
-uvx --from git+https://github.com/github/spec-kit.git@v0.11.8 specify init . --integration copilot --integration-options="--skills"
+uvx --from specify-cli specify init . --integration copilot --integration-options="--skills"
 ```
 
 If neither `uv` nor `pipx` is available, tell the user to install `uv` first
@@ -58,7 +59,9 @@ specify check
   finds that `specify` is not available, it should run this skill's detect/install
   steps first, then retry.
 - For an **already-installed** CLI that just needs a newer version, prefer the
-  **speckit-self** skill (`specify self upgrade`) over reinstalling.
-- Replace `@v0.11.8` with the latest tag from
-  <https://github.com/github/spec-kit/releases> if you intentionally want the newest
-  release rather than the version this plugin targets.
+  **speckit-self** skill (`specify self upgrade`) over reinstalling. To refresh a
+  `uv`/`pipx` install to the latest PyPI release, use `uv tool upgrade specify-cli`
+  or `pipx upgrade specify-cli`.
+- Installing from PyPI always pulls the latest published `specify-cli`. Only pin a
+  specific version (e.g. `uv tool install "specify-cli==0.15.0"`) if you have a
+  concrete reason to hold back.

--- a/skills/speckit-init/SKILL.md
+++ b/skills/speckit-init/SKILL.md
@@ -44,36 +44,52 @@ it first, then continue.
 infrastructure, and the Copilot command files. It runs offline from assets
 bundled in the installed CLI.
 
-Common forms (always Copilot + skills mode):
+Common forms (always Copilot + skills mode). Pick the `--script` flavor for the
+user's OS — `sh` on **macOS/Linux**, `ps` on **Windows** (the examples below use
+`sh`; swap in `--script ps` on Windows):
 
 ```bash
 # New project directory
-specify init <project-name> --integration copilot --integration-options="--skills"
+specify init <project-name> --integration copilot --integration-options="--skills" --script sh
 
 # Initialize in the current directory
-specify init . --integration copilot --integration-options="--skills"
-specify init --here --integration copilot --integration-options="--skills"
+specify init . --integration copilot --integration-options="--skills" --script sh
+specify init --here --integration copilot --integration-options="--skills" --script sh
 
 # Current directory is non-empty: skip the confirmation prompt
-specify init --here --integration copilot --integration-options="--skills" --force
+specify init --here --integration copilot --integration-options="--skills" --script sh --force
 
 # Install a preset at init time
-specify init <project-name> --integration copilot --integration-options="--skills" --preset healthcare-compliance
+specify init <project-name> --integration copilot --integration-options="--skills" --script sh --preset healthcare-compliance
+```
+
+On Windows, use `--script ps` instead:
+
+```powershell
+specify init <project-name> --integration copilot --integration-options="--skills" --script ps
 ```
 
 ### Key options
 
 - `--integration copilot` — always use this in the Copilot plugin.
 - `--integration-options="--skills"` — **required**; scaffolds spec-kit commands as Copilot Agent Skills (`SKILL.md`) instead of `.agent.md` files.
+- `--script <sh|ps|py>` — choose the helper script flavor. **Required in non-interactive
+  shells** (like this agent session): omitting it makes `specify init` prompt for the
+  script type and hang. Use `sh` on **macOS/Linux**, `ps` on **Windows**; `py` is a
+  cross-platform Python fallback.
+- `--ignore-agent-tools` — skip checks for the agent's CLI tools. **Recommended** for the
+  Copilot plugin so init doesn't fail on missing external agent CLIs.
 - `--here` / `.` — initialize in the current directory instead of creating a new one.
 - `--force` — skip the confirmation when `--here` targets a non-empty directory.
 - `--preset <id>` — install a preset during initialization.
-- `--script <sh|ps>` — choose the helper script flavor.
-- `--ignore-agent-tools` — skip checks for the agent's CLI tools.
 
 ## Notes
 
 - Prefer non-interactive flags so the command does not block on prompts.
+- **Always pass `--script`** (`sh` on macOS/Linux, `ps` on Windows, `py` anywhere).
+  In a non-interactive session `specify init` auto-defaults `--integration`, but it does
+  **not** default `--script` — so omitting it drops into an interactive prompt and hangs
+  the agent shell. This is the most common cause of `specify init` appearing to freeze.
 - Always pass both `--integration copilot` and `--integration-options="--skills"`;
   the skills layout is what makes spec-kit commands (and later-added extensions)
   show up as `SKILL.md` for Copilot.

--- a/skills/speckit-init/SKILL.md
+++ b/skills/speckit-init/SKILL.md
@@ -73,10 +73,13 @@ specify init <project-name> --integration copilot --integration-options="--skill
 
 - `--integration copilot` — always use this in the Copilot plugin.
 - `--integration-options="--skills"` — **required**; scaffolds spec-kit commands as Copilot Agent Skills (`SKILL.md`) instead of `.agent.md` files.
-- `--script <sh|ps|py>` — choose the helper script flavor. **Required in non-interactive
-  shells** (like this agent session): omitting it makes `specify init` prompt for the
-  script type and hang. Use `sh` on **macOS/Linux**, `ps` on **Windows**; `py` is a
-  cross-platform Python fallback.
+- `--script <sh|ps|py>` — choose the helper script flavor. **Always pass this when
+  running `specify init` for the user.** When stdin is a TTY — which the agent shell
+  allocates — omitting `--script` opens an interactive "Choose script type" chooser that
+  blocks the command. (With genuinely non-interactive stdin, e.g. a closed pipe, the CLI
+  instead auto-selects the OS default, but you can't rely on that from a PTY-backed agent
+  session.) Use `sh` on **macOS/Linux**, `ps` on **Windows**; `py` is a cross-platform
+  Python fallback.
 - `--ignore-agent-tools` — skip checks for the agent's CLI tools. **Recommended** for the
   Copilot plugin so init doesn't fail on missing external agent CLIs.
 - `--here` / `.` — initialize in the current directory instead of creating a new one.
@@ -87,9 +90,12 @@ specify init <project-name> --integration copilot --integration-options="--skill
 
 - Prefer non-interactive flags so the command does not block on prompts.
 - **Always pass `--script`** (`sh` on macOS/Linux, `ps` on Windows, `py` anywhere).
-  In a non-interactive session `specify init` auto-defaults `--integration`, but it does
-  **not** default `--script` — so omitting it drops into an interactive prompt and hangs
-  the agent shell. This is the most common cause of `specify init` appearing to freeze.
+  When `specify init` runs with a TTY on stdin — as it does in a PTY-backed agent
+  session — omitting `--script` opens an interactive "Choose script type" chooser that
+  blocks. (`--integration copilot` already suppresses the *integration* chooser, but the
+  *script-type* chooser still appears.) The CLI only auto-selects the OS default when
+  stdin is genuinely non-interactive (e.g. a closed pipe), which you can't count on here,
+  so this is the most common cause of `specify init` appearing to freeze.
 - Always pass both `--integration copilot` and `--integration-options="--skills"`;
   the skills layout is what makes spec-kit commands (and later-added extensions)
   show up as `SKILL.md` for Copilot.

--- a/skills/speckit-preset/SKILL.md
+++ b/skills/speckit-preset/SKILL.md
@@ -48,8 +48,10 @@ specify preset catalog remove <name>
 ## Notes
 
 - Resolution priority: **lower number = higher precedence** (default `10`).
-- A preset can also be installed at project creation: `specify init <name> --preset <id>`
-  (see the speckit-init skill).
+- A preset can also be installed at project creation:
+  `specify init <name> --integration copilot --integration-options="--skills" --script sh --preset <id>`
+  (use `--script ps` on Windows; see the speckit-init skill for the full OS-aware form and
+  why `--script` is required).
 - Use `specify preset resolve` to debug unexpected template resolution.
 - Unlike extensions/bundles, `specify preset add` does **not** scaffold skills — a
   preset overrides the **templates** used to generate command content and is applied


### PR DESCRIPTION
## Summary

Fixes the `speckit-init` skill hanging in agent shells, moves CLI installation off hard-pinned git tags onto the PyPI mechanism, removes the "lockstep with Specify CLI" versioning convention, and aligns the plugin version with the current Spec Kit release.

## Changes

### `speckit-init` — fix the hang
- Root cause (validated under a real PTY): omitting `--script` makes `specify init` show an interactive arrow-key "Choose script type" menu that blocks. `--integration copilot` already suppresses the integration prompt, but the script-type prompt still appears.
- All examples now pass `--script`, OS-aware: `sh` on macOS/Linux, `ps` on Windows, `py` as a cross-platform fallback.
- `--script` documented as **required in non-interactive shells**; `--ignore-agent-tools` marked **recommended**.

### `speckit-cli-setup` — install from PyPI, no hard pin
- Replaced `git+https://github.com/github/spec-kit.git@v0.11.8` install commands with the PyPI mechanism (`uv tool install specify-cli`, `pipx install specify-cli`, `uvx --from specify-cli specify …`).
- Added upgrade guidance (`uv tool upgrade` / `pipx upgrade`); pinning is now opt-in only.

### De-lockstep the versioning docs
- README, CONTRIBUTING, and AGENTS.md no longer describe the plugin as "lockstep" with the Specify CLI. The plugin targets the **latest** `specify-cli` from PyPI (minimum floor `>= 0.11`), and `plugin.json`'s version is an **independent** semver.
- Documented that `specify init` stamps the installed CLI version into the generated project, so the CLI version is determined at init time, not by this plugin.
- Corrected the stale `copilot plugin install ./` reinstall step to the marketplace/repo flow.

### Version alignment
- Bumped `plugin.json` and both `.github/plugin/marketplace.json` entries to **0.15.0** to align with the current Spec Kit release. One-time alignment, not a re-pin.

## Validation
- Reproduced the hang under a real PTY with `--script` omitted; confirmed `--script sh` completes cleanly.
- Confirmed `--script sh` → `bash` and `--script ps` → `powershell` in the generated project.
- Verified the PyPI install mechanism resolves; `specify-cli` latest on PyPI is 0.15.0.
- Both JSON manifests parse and report `0.15.0`.
