### PR TITLE
docs: explain how to open the canvas dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ right `specify` command. For example:
 - "Install the platform-starter bundle" → `speckit-bundle`
 - "Is there a newer specify release?" → `speckit-self`
 
+### Opening a canvas dashboard
+
+The **Assessment canvas** and **Bug fix canvas** plugins are *canvas extensions*:
+they render in the **GitHub Copilot app** side panel, not the terminal CLI.
+Installing one only registers its canvas — nothing opens automatically. To open a
+dashboard, ask Copilot, e.g. **"Open the Idea Assessment pipeline"** or **"Open
+the Bug Fix Pipeline"**. The agent opens the matching canvas in a side panel;
+from there you can click its buttons or ask the agent to drive the stages. There
+is no slash command or menu entry. See each plugin's README for details.
+
 ## Walkthroughs
 
 > [!NOTE]

--- a/plugins/spec-kit-copilot-assess/extensions/assess-canvas/README.md
+++ b/plugins/spec-kit-copilot-assess/extensions/assess-canvas/README.md
@@ -45,6 +45,29 @@ The canvas is **read-only against the filesystem**; it never writes assessment
 files. All changes happen through the `assess` commands themselves, so the
 extension's safety guardrails still apply.
 
+## Opening the dashboard
+
+This is a **canvas extension**, so it renders in the **GitHub Copilot app** side
+panel — not in the plain terminal CLI. Installing the plugin only *registers* the
+canvas; nothing opens automatically.
+
+To open it, ask Copilot in chat, e.g. **"Open the Idea Assessment pipeline"** (or
+"open the assessment dashboard"). The agent matches your request to this canvas
+(`id: assess-canvas`, displayName **"Idea Assessment"**) and opens it in a side
+panel. There is no slash command or menu entry — discovery is the agent matching
+the canvas name/description.
+
+Once it is open you can drive it two ways:
+
+- **Click the panel** — the intake form and each card's Run/Rerun and Clarify
+  buttons.
+- **Ask the agent** — the canvas also exposes agent-callable actions
+  (`list_assessments`, `setup_assess`, `run_stage`, `clarify_item`), so "run the
+  research stage on <slug>" works too.
+
+If the project isn't set up for Spec Kit or the `assess` extension isn't
+installed, the canvas shows a setup step first.
+
 ## How it drives the pipeline
 
 Buttons in the canvas POST to a loopback HTTP endpoint, which calls

--- a/plugins/spec-kit-copilot-bugfix/extensions/bugfix-canvas/README.md
+++ b/plugins/spec-kit-copilot-bugfix/extensions/bugfix-canvas/README.md
@@ -46,6 +46,29 @@ The canvas is **read-only against the filesystem**; it never writes bug files.
 All changes happen through the `bug` commands themselves, so the extension's
 safety guardrails still apply (only `speckit-bug-fix` ever edits source code).
 
+## Opening the dashboard
+
+This is a **canvas extension**, so it renders in the **GitHub Copilot app** side
+panel — not in the plain terminal CLI. Installing the plugin only *registers* the
+canvas; nothing opens automatically.
+
+To open it, ask Copilot in chat, e.g. **"Open the Bug Fix Pipeline"** (or "open
+the bug fix dashboard"). The agent matches your request to this canvas
+(`id: bugfix-canvas`, displayName **"Bug Fix Pipeline"**) and opens it in a side
+panel. There is no slash command or menu entry — discovery is the agent matching
+the canvas name/description.
+
+Once it is open you can drive it two ways:
+
+- **Click the panel** — the New bug → assess form and each card's Run/Rerun and
+  Clarify buttons.
+- **Ask the agent** — the canvas also exposes agent-callable actions
+  (`list_bugs`, `setup_bug`, `run_stage`, `clarify_item`), so "run assess on this
+  stack trace in the bug pipeline" works too.
+
+If the project isn't set up for Spec Kit or the `bug` extension isn't installed,
+the canvas shows a setup step first.
+
 ## How it drives the pipeline
 
 Buttons in the canvas POST to a loopback HTTP endpoint, which calls


### PR DESCRIPTION
## Summary

The plugin READMEs documented **installation** but never explained how to actually **open** the Bug Fix Pipeline or Idea Assessment dashboards — an easy thing to miss, since installing a canvas extension only *registers* the canvas and nothing appears until you ask Copilot to open it.

This PR adds that missing guidance:

- **`plugins/spec-kit-copilot-bugfix/extensions/bugfix-canvas/README.md`** — new **Opening the dashboard** section.
- **`plugins/spec-kit-copilot-assess/extensions/assess-canvas/README.md`** — new **Opening the dashboard** section.
- **`README.md`** — new **Opening a canvas dashboard** note under Usage covering both plugins.

## What the docs now clarify

- These are **canvas extensions**: they render in the **GitHub Copilot app** side panel, not the plain terminal CLI.
- Installing only registers the canvas; you open it by **asking Copilot** — e.g. *"Open the Bug Fix Pipeline"* or *"Open the Idea Assessment pipeline"* — and the agent matches the request to the canvas (`bugfix-canvas` / `assess-canvas`) and opens it.
- There is **no slash command or menu entry**; discovery is the agent matching the canvas name/description.
- Once open, you can drive it via the panel buttons **or** the agent-callable actions (`list_bugs`/`list_assessments`, `setup_*`, `run_stage`, `clarify_item`).

Docs-only; no code changes.