### PR TITLE
Fix broken wizard-canvas screenshot link in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ own README for full details.
 
 | Bug Fix | Spec Kit Wizard |
 | --- | --- |
-| [![bugfix-canvas](docs/images/bugfix-canvas.png)](docs/images/bugfix-canvas.png) | [![wizard-canvas](docs/images/wizard-canvas.png)](docs/images/wizard-canvas.png) |
+| [![bugfix-canvas](docs/images/bugfix-canvas.png)](docs/images/bugfix-canvas.png) | [![wizard-canvas](docs/images/wizard-phases.png)](docs/images/wizard-phases.png) |
 
 
 ## Requirements


### PR DESCRIPTION
The root README's plugin-gallery table pointed at docs/images/wizard-canvas.png, which was renamed in PR #11 to per-page screenshots (wizard-environment.png, wizard-catalogs.png, wizard-composition.png, wizard-phases.png).

Point the wizard gallery entry at wizard-phases.png so the image renders.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>