### PR TITLE
Vendor js-yaml + graceful degradation so canvas opens without npm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/** text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 .DS_Store
 node_modules/
+# Exception: the Spec Kit Wizard canvas ships a trimmed vendored copy of
+# js-yaml + argparse so the extension works without an on-first-open
+# `npm install` (Copilot CLI doesn't run npm; users on corporate networks
+# often can't reach registry.npmjs.org over TLS).
+!plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/
+!plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/**
 .playwright-mcp/
 
 # Session artifacts (canvas runtime state, spec-kit init output, css coverage snapshots)

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/extension.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/extension.mjs
@@ -75,11 +75,15 @@ async function onOpen(ctx) {
     inst.workspacePath = resolveWorkspace(inst, ctx, sessionState.repoPath);
 
     // First-boot / new-worktree bootstrap: the wizard canvas has a small npm
-    // dependency (js-yaml) that isn't checked in. If it's missing, run
-    // `npm install` in the canvas folder automatically before starting
-    // the server. This adds a one-time ~10-30s delay on first open of a
-    // fresh worktree but avoids surfacing a raw error that the user then
-    // has to resolve manually.
+    // dependency (js-yaml) that is now vendored under node_modules/ in the
+    // shipped plugin (see .gitignore exception). checkDeps() is kept as a
+    // belt-and-suspenders probe: if the vendored copy has somehow been
+    // stripped (e.g. an over-aggressive gitignore in a downstream fork, or
+    // a manual `rm -rf node_modules/`), we still attempt to run
+    // `npm install` and, if THAT also fails (offline machine, corporate
+    // TLS block, etc.), we open the canvas in a degraded mode rather than
+    // refusing to start. Only the Catalogs/Composition pages need
+    // js-yaml — everything else works without it.
     let deps = await checkDeps();
     if (!deps.ready) {
         const installResult = await installDeps(deps.missing);
@@ -88,9 +92,13 @@ async function onOpen(ctx) {
             const extDir = getExtensionDir();
             const pkgs = deps.missing.join(" ");
             const detail = installResult.stderr?.trim() || installResult.stdout?.trim() || "npm install failed";
-            throw new Error(
-                `Spec Kit Wizard cannot start: automatic install of npm dependencies (${pkgs}) failed. ` +
-                `Run: npm install ${pkgs}  (in ${extDir}), then reopen the canvas.\n\n${detail}`,
+            // Downgrade from a hard start error to a runtime warning: log
+            // for diagnostics and let the UI surface a banner instead.
+            const adapter = sessionAdapter();
+            adapter.log?.(
+                `[speckit-wizard] npm dependency (${pkgs}) missing and auto-install failed; ` +
+                `Catalogs/Composition YAML parsing will be disabled. ` +
+                `To restore full function, run: npm install ${pkgs} (in ${extDir}). Details: ${detail}`,
             );
         }
     }

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/CHANGELOG.md
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/CHANGELOG.md
@@ -1,0 +1,216 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [2.0.1] - 2020-08-29
+### Fixed
+- Fix issue with `process.argv` when used with interpreters (`coffee`, `ts-node`, etc.), #150.
+
+
+## [2.0.0] - 2020-08-14
+### Changed
+- Full rewrite. Now port from python 3.9.0 & more precise following.
+  See [doc](./doc) for difference and migration info.
+- node.js 10+ required
+- Removed most of local docs in favour of original ones.
+
+
+## [1.0.10] - 2018-02-15
+### Fixed
+- Use .concat instead of + for arrays, #122.
+
+
+## [1.0.9] - 2016-09-29
+### Changed
+- Rerelease after 1.0.8 - deps cleanup.
+
+
+## [1.0.8] - 2016-09-29
+### Changed
+- Maintenance (deps bump, fix node 6.5+ tests, coverage report).
+
+
+## [1.0.7] - 2016-03-17
+### Changed
+- Teach `addArgument` to accept string arg names. #97, @tomxtobin.
+
+
+## [1.0.6] - 2016-02-06
+### Changed
+- Maintenance: moved to eslint & updated CS.
+
+
+## [1.0.5] - 2016-02-05
+### Changed
+- Removed lodash dependency to significantly reduce install size.
+  Thanks to @mourner.
+
+
+## [1.0.4] - 2016-01-17
+### Changed
+- Maintenance: lodash update to 4.0.0.
+
+
+## [1.0.3] - 2015-10-27
+### Fixed
+- Fix parse `=` in args: `--examplepath="C:\myfolder\env=x64"`. #84, @CatWithApple.
+
+
+## [1.0.2] - 2015-03-22
+### Changed
+- Relaxed lodash version dependency.
+
+
+## [1.0.1] - 2015-02-20
+### Changed
+- Changed dependencies to be compatible with ancient nodejs.
+
+
+## [1.0.0] - 2015-02-19
+### Changed
+- Maintenance release.
+- Replaced `underscore` with `lodash`.
+- Bumped version to 1.0.0 to better reflect semver meaning.
+- HISTORY.md -> CHANGELOG.md
+
+
+## [0.1.16] - 2013-12-01
+### Changed
+- Maintenance release. Updated dependencies and docs.
+
+
+## [0.1.15] - 2013-05-13
+### Fixed
+- Fixed #55, @trebor89
+
+
+## [0.1.14] - 2013-05-12
+### Fixed
+- Fixed #62, @maxtaco
+
+
+## [0.1.13] - 2013-04-08
+### Changed
+- Added `.npmignore` to reduce package size
+
+
+## [0.1.12] - 2013-02-10
+### Fixed
+- Fixed conflictHandler (#46), @hpaulj
+
+
+## [0.1.11] - 2013-02-07
+### Added
+- Added 70+ tests (ported from python), @hpaulj
+- Added conflictHandler, @applepicke
+- Added fromfilePrefixChar, @hpaulj
+
+### Fixed
+- Multiple bugfixes, @hpaulj
+
+
+## [0.1.10] - 2012-12-30
+### Added
+- Added [mutual exclusion](http://docs.python.org/dev/library/argparse.html#mutual-exclusion)
+  support, thanks to @hpaulj
+
+### Fixed
+- Fixed options check for `storeConst` & `appendConst` actions, thanks to @hpaulj
+
+
+## [0.1.9] - 2012-12-27
+### Fixed
+- Fixed option dest interferens with other options (issue #23), thanks to @hpaulj
+- Fixed default value behavior with `*` positionals, thanks to @hpaulj
+- Improve `getDefault()` behavior, thanks to @hpaulj
+- Improve negative argument parsing, thanks to @hpaulj
+
+
+## [0.1.8] - 2012-12-01
+### Fixed
+- Fixed parser parents (issue #19), thanks to @hpaulj
+- Fixed negative argument parse (issue #20), thanks to @hpaulj
+
+
+## [0.1.7] - 2012-10-14
+### Fixed
+- Fixed 'choices' argument parse (issue #16)
+- Fixed stderr output (issue #15)
+
+
+## [0.1.6] - 2012-09-09
+### Fixed
+- Fixed check for conflict of options (thanks to @tomxtobin)
+
+
+## [0.1.5] - 2012-09-03
+### Fixed
+- Fix parser #setDefaults method (thanks to @tomxtobin)
+
+
+## [0.1.4] - 2012-07-30
+### Fixed
+- Fixed pseudo-argument support (thanks to @CGamesPlay)
+- Fixed addHelp default (should be true), if not set (thanks to @benblank)
+
+
+## [0.1.3] - 2012-06-27
+### Fixed
+- Fixed formatter api name: Formatter -> HelpFormatter
+
+
+## [0.1.2] - 2012-05-29
+### Fixed
+- Removed excess whitespace in help
+- Fixed error reporting, when parcer with subcommands
+  called with empty arguments
+
+### Added
+- Added basic tests
+
+
+## [0.1.1] - 2012-05-23
+### Fixed
+- Fixed line wrapping in help formatter
+- Added better error reporting on invalid arguments
+
+
+## [0.1.0] - 2012-05-16
+### Added
+- First release.
+
+
+[2.0.1]: https://github.com/nodeca/argparse/compare/2.0.0...2.0.1
+[2.0.0]: https://github.com/nodeca/argparse/compare/1.0.10...2.0.0
+[1.0.10]: https://github.com/nodeca/argparse/compare/1.0.9...1.0.10
+[1.0.9]: https://github.com/nodeca/argparse/compare/1.0.8...1.0.9
+[1.0.8]: https://github.com/nodeca/argparse/compare/1.0.7...1.0.8
+[1.0.7]: https://github.com/nodeca/argparse/compare/1.0.6...1.0.7
+[1.0.6]: https://github.com/nodeca/argparse/compare/1.0.5...1.0.6
+[1.0.5]: https://github.com/nodeca/argparse/compare/1.0.4...1.0.5
+[1.0.4]: https://github.com/nodeca/argparse/compare/1.0.3...1.0.4
+[1.0.3]: https://github.com/nodeca/argparse/compare/1.0.2...1.0.3
+[1.0.2]: https://github.com/nodeca/argparse/compare/1.0.1...1.0.2
+[1.0.1]: https://github.com/nodeca/argparse/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/nodeca/argparse/compare/0.1.16...1.0.0
+[0.1.16]: https://github.com/nodeca/argparse/compare/0.1.15...0.1.16
+[0.1.15]: https://github.com/nodeca/argparse/compare/0.1.14...0.1.15
+[0.1.14]: https://github.com/nodeca/argparse/compare/0.1.13...0.1.14
+[0.1.13]: https://github.com/nodeca/argparse/compare/0.1.12...0.1.13
+[0.1.12]: https://github.com/nodeca/argparse/compare/0.1.11...0.1.12
+[0.1.11]: https://github.com/nodeca/argparse/compare/0.1.10...0.1.11
+[0.1.10]: https://github.com/nodeca/argparse/compare/0.1.9...0.1.10
+[0.1.9]: https://github.com/nodeca/argparse/compare/0.1.8...0.1.9
+[0.1.8]: https://github.com/nodeca/argparse/compare/0.1.7...0.1.8
+[0.1.7]: https://github.com/nodeca/argparse/compare/0.1.6...0.1.7
+[0.1.6]: https://github.com/nodeca/argparse/compare/0.1.5...0.1.6
+[0.1.5]: https://github.com/nodeca/argparse/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/nodeca/argparse/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/nodeca/argparse/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/nodeca/argparse/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/nodeca/argparse/compare/0.1.0...0.1.1
+[0.1.0]: https://github.com/nodeca/argparse/releases/tag/0.1.0

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/LICENSE
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/LICENSE
@@ -1,0 +1,254 @@
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+as a successor of a language called ABC.  Guido remains Python's
+principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for
+National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+in Reston, Virginia where he released several versions of the
+software.
+
+In May 2000, Guido and the Python core development team moved to
+BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+year, the PythonLabs team moved to Digital Creations, which became
+Zope Corporation.  In 2001, the Python Software Foundation (PSF, see
+https://www.python.org/psf/) was formed, a non-profit organization
+created specifically to own Python-related Intellectual Property.
+Zope Corporation was a sponsoring member of the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for
+the Open Source Definition).  Historically, most, but not all, Python
+releases have also been GPL-compatible; the table below summarizes
+the various releases.
+
+    Release         Derived     Year        Owner       GPL-
+                    from                                compatible? (1)
+
+    0.9.0 thru 1.2              1991-1995   CWI         yes
+    1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+    1.6             1.5.2       2000        CNRI        no
+    2.0             1.6         2000        BeOpen.com  no
+    1.6.1           1.6         2001        CNRI        yes (2)
+    2.1             2.0+1.6.1   2001        PSF         no
+    2.0.1           2.0+1.6.1   2001        PSF         yes
+    2.1.1           2.1+2.0.1   2001        PSF         yes
+    2.1.2           2.1.1       2002        PSF         yes
+    2.1.3           2.1.2       2002        PSF         yes
+    2.2 and above   2.1.1       2001-now    PSF         yes
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+    the GPL.  All Python licenses, unlike the GPL, let you distribute
+    a modified version without making your changes open source.  The
+    GPL-compatible licenses make it possible to combine Python with
+    other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+    because its license has a choice of law clause.  According to
+    CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+    is "not incompatible" with the GPL.
+
+Thanks to the many outside volunteers who have worked under Guido's
+direction to make these releases possible.
+
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an "AS IS"
+basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions.  Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee.  This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party.  As an exception, the "BeOpen Python" logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 ("CNRI"), and the Individual or Organization
+("Licensee") accessing and otherwise using Python 1.6.1 software in
+source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python 1.6.1
+alone or in any derivative version, provided, however, that CNRI's
+License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+1995-2001 Corporation for National Research Initiatives; All Rights
+Reserved" are retained in Python 1.6.1 alone or in any derivative
+version prepared by Licensee.  Alternately, in lieu of CNRI's License
+Agreement, Licensee may substitute the following text (omitting the
+quotes): "Python 1.6.1 is made available subject to the terms and
+conditions in CNRI's License Agreement.  This Agreement together with
+Python 1.6.1 may be located on the Internet using the following
+unique, persistent identifier (known as a handle): 1895.22/1013.  This
+Agreement may also be obtained from a proxy server on the Internet
+using the following URL: http://hdl.handle.net/1895.22/1013".
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6.1 or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python 1.6.1.
+
+4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by the federal
+intellectual property law of the United States, including without
+limitation the federal copyright law, and, to the extent such
+U.S. federal law does not apply, by the law of the Commonwealth of
+Virginia, excluding Virginia's conflict of law provisions.
+Notwithstanding the foregoing, with regard to derivative works based
+on Python 1.6.1 that incorporate non-separable material that was
+previously distributed under the GNU General Public License (GPL), the
+law of the Commonwealth of Virginia shall govern this License
+Agreement only as to issues arising under or with respect to
+Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+License Agreement shall be deemed to create any relationship of
+agency, partnership, or joint venture between CNRI and Licensee.  This
+License Agreement does not grant permission to use CNRI trademarks or
+trade name in a trademark sense to endorse or promote products or
+services of Licensee, or any third party.
+
+8. By clicking on the "ACCEPT" button where indicated, or by copying,
+installing or otherwise using Python 1.6.1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+        ACCEPT
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands.  All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/README.md
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/README.md
@@ -1,0 +1,84 @@
+argparse
+========
+
+[![Build Status](https://secure.travis-ci.org/nodeca/argparse.svg?branch=master)](http://travis-ci.org/nodeca/argparse)
+[![NPM version](https://img.shields.io/npm/v/argparse.svg)](https://www.npmjs.org/package/argparse)
+
+CLI arguments parser for node.js, with [sub-commands](https://docs.python.org/3.9/library/argparse.html#sub-commands) support. Port of python's [argparse](http://docs.python.org/dev/library/argparse.html) (version [3.9.0](https://github.com/python/cpython/blob/v3.9.0rc1/Lib/argparse.py)).
+
+**Difference with original.**
+
+- JS has no keyword arguments support.
+  -  Pass options instead: `new ArgumentParser({ description: 'example', add_help: true })`.
+- JS has no python's types `int`, `float`, ...
+  - Use string-typed names: `.add_argument('-b', { type: 'int', help: 'help' })`.
+- `%r` format specifier uses `require('util').inspect()`.
+
+More details in [doc](./doc).
+
+
+Example
+-------
+
+`test.js` file:
+
+```javascript
+#!/usr/bin/env node
+'use strict';
+
+const { ArgumentParser } = require('argparse');
+const { version } = require('./package.json');
+
+const parser = new ArgumentParser({
+  description: 'Argparse example'
+});
+
+parser.add_argument('-v', '--version', { action: 'version', version });
+parser.add_argument('-f', '--foo', { help: 'foo bar' });
+parser.add_argument('-b', '--bar', { help: 'bar foo' });
+parser.add_argument('--baz', { help: 'baz bar' });
+
+console.dir(parser.parse_args());
+```
+
+Display help:
+
+```
+$ ./test.js -h
+usage: test.js [-h] [-v] [-f FOO] [-b BAR] [--baz BAZ]
+
+Argparse example
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -v, --version      show program's version number and exit
+  -f FOO, --foo FOO  foo bar
+  -b BAR, --bar BAR  bar foo
+  --baz BAZ          baz bar
+```
+
+Parse arguments:
+
+```
+$ ./test.js -f=3 --bar=4 --baz 5
+{ foo: '3', bar: '4', baz: '5' }
+```
+
+
+API docs
+--------
+
+Since this is a port with minimal divergence, there's no separate documentation.
+Use original one instead, with notes about difference.
+
+1. [Original doc](https://docs.python.org/3.9/library/argparse.html).
+2. [Original tutorial](https://docs.python.org/3.9/howto/argparse.html).
+3. [Difference with python](./doc).
+
+
+argparse for enterprise
+-----------------------
+
+Available as part of the Tidelift Subscription
+
+The maintainers of argparse and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-argparse?utm_source=npm-argparse&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/argparse.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/argparse.js
@@ -1,0 +1,3707 @@
+// Port of python's argparse module, version 3.9.0:
+// https://github.com/python/cpython/blob/v3.9.0rc1/Lib/argparse.py
+
+'use strict'
+
+// Copyright (C) 2010-2020 Python Software Foundation.
+// Copyright (C) 2020 argparse.js authors
+
+/*
+ * Command-line parsing library
+ *
+ * This module is an optparse-inspired command-line parsing library that:
+ *
+ *     - handles both optional and positional arguments
+ *     - produces highly informative usage messages
+ *     - supports parsers that dispatch to sub-parsers
+ *
+ * The following is a simple usage example that sums integers from the
+ * command-line and writes the result to a file::
+ *
+ *     parser = argparse.ArgumentParser(
+ *         description='sum the integers at the command line')
+ *     parser.add_argument(
+ *         'integers', metavar='int', nargs='+', type=int,
+ *         help='an integer to be summed')
+ *     parser.add_argument(
+ *         '--log', default=sys.stdout, type=argparse.FileType('w'),
+ *         help='the file where the sum should be written')
+ *     args = parser.parse_args()
+ *     args.log.write('%s' % sum(args.integers))
+ *     args.log.close()
+ *
+ * The module contains the following public classes:
+ *
+ *     - ArgumentParser -- The main entry point for command-line parsing. As the
+ *         example above shows, the add_argument() method is used to populate
+ *         the parser with actions for optional and positional arguments. Then
+ *         the parse_args() method is invoked to convert the args at the
+ *         command-line into an object with attributes.
+ *
+ *     - ArgumentError -- The exception raised by ArgumentParser objects when
+ *         there are errors with the parser's actions. Errors raised while
+ *         parsing the command-line are caught by ArgumentParser and emitted
+ *         as command-line messages.
+ *
+ *     - FileType -- A factory for defining types of files to be created. As the
+ *         example above shows, instances of FileType are typically passed as
+ *         the type= argument of add_argument() calls.
+ *
+ *     - Action -- The base class for parser actions. Typically actions are
+ *         selected by passing strings like 'store_true' or 'append_const' to
+ *         the action= argument of add_argument(). However, for greater
+ *         customization of ArgumentParser actions, subclasses of Action may
+ *         be defined and passed as the action= argument.
+ *
+ *     - HelpFormatter, RawDescriptionHelpFormatter, RawTextHelpFormatter,
+ *         ArgumentDefaultsHelpFormatter -- Formatter classes which
+ *         may be passed as the formatter_class= argument to the
+ *         ArgumentParser constructor. HelpFormatter is the default,
+ *         RawDescriptionHelpFormatter and RawTextHelpFormatter tell the parser
+ *         not to change the formatting for help text, and
+ *         ArgumentDefaultsHelpFormatter adds information about argument defaults
+ *         to the help.
+ *
+ * All other classes in this module are considered implementation details.
+ * (Also note that HelpFormatter and RawDescriptionHelpFormatter are only
+ * considered public as object names -- the API of the formatter objects is
+ * still considered an implementation detail.)
+ */
+
+const SUPPRESS = '==SUPPRESS=='
+
+const OPTIONAL = '?'
+const ZERO_OR_MORE = '*'
+const ONE_OR_MORE = '+'
+const PARSER = 'A...'
+const REMAINDER = '...'
+const _UNRECOGNIZED_ARGS_ATTR = '_unrecognized_args'
+
+
+// ==================================
+// Utility functions used for porting
+// ==================================
+const assert = require('assert')
+const util = require('util')
+const fs = require('fs')
+const sub = require('./lib/sub')
+const path = require('path')
+const repr = util.inspect
+
+function get_argv() {
+    // omit first argument (which is assumed to be interpreter - `node`, `coffee`, `ts-node`, etc.)
+    return process.argv.slice(1)
+}
+
+function get_terminal_size() {
+    return {
+        columns: +process.env.COLUMNS || process.stdout.columns || 80
+    }
+}
+
+function hasattr(object, name) {
+    return Object.prototype.hasOwnProperty.call(object, name)
+}
+
+function getattr(object, name, value) {
+    return hasattr(object, name) ? object[name] : value
+}
+
+function setattr(object, name, value) {
+    object[name] = value
+}
+
+function setdefault(object, name, value) {
+    if (!hasattr(object, name)) object[name] = value
+    return object[name]
+}
+
+function delattr(object, name) {
+    delete object[name]
+}
+
+function range(from, to, step=1) {
+    // range(10) is equivalent to range(0, 10)
+    if (arguments.length === 1) [ to, from ] = [ from, 0 ]
+    if (typeof from !== 'number' || typeof to !== 'number' || typeof step !== 'number') {
+        throw new TypeError('argument cannot be interpreted as an integer')
+    }
+    if (step === 0) throw new TypeError('range() arg 3 must not be zero')
+
+    let result = []
+    if (step > 0) {
+        for (let i = from; i < to; i += step) result.push(i)
+    } else {
+        for (let i = from; i > to; i += step) result.push(i)
+    }
+    return result
+}
+
+function splitlines(str, keepends = false) {
+    let result
+    if (!keepends) {
+        result = str.split(/\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/)
+    } else {
+        result = []
+        let parts = str.split(/(\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029])/)
+        for (let i = 0; i < parts.length; i += 2) {
+            result.push(parts[i] + (i + 1 < parts.length ? parts[i + 1] : ''))
+        }
+    }
+    if (!result[result.length - 1]) result.pop()
+    return result
+}
+
+function _string_lstrip(string, prefix_chars) {
+    let idx = 0
+    while (idx < string.length && prefix_chars.includes(string[idx])) idx++
+    return idx ? string.slice(idx) : string
+}
+
+function _string_split(string, sep, maxsplit) {
+    let result = string.split(sep)
+    if (result.length > maxsplit) {
+        result = result.slice(0, maxsplit).concat([ result.slice(maxsplit).join(sep) ])
+    }
+    return result
+}
+
+function _array_equal(array1, array2) {
+    if (array1.length !== array2.length) return false
+    for (let i = 0; i < array1.length; i++) {
+        if (array1[i] !== array2[i]) return false
+    }
+    return true
+}
+
+function _array_remove(array, item) {
+    let idx = array.indexOf(item)
+    if (idx === -1) throw new TypeError(sub('%r not in list', item))
+    array.splice(idx, 1)
+}
+
+// normalize choices to array;
+// this isn't required in python because `in` and `map` operators work with anything,
+// but in js dealing with multiple types here is too clunky
+function _choices_to_array(choices) {
+    if (choices === undefined) {
+        return []
+    } else if (Array.isArray(choices)) {
+        return choices
+    } else if (choices !== null && typeof choices[Symbol.iterator] === 'function') {
+        return Array.from(choices)
+    } else if (typeof choices === 'object' && choices !== null) {
+        return Object.keys(choices)
+    } else {
+        throw new Error(sub('invalid choices value: %r', choices))
+    }
+}
+
+// decorator that allows a class to be called without new
+function _callable(cls) {
+    let result = { // object is needed for inferred class name
+        [cls.name]: function (...args) {
+            let this_class = new.target === result || !new.target
+            return Reflect.construct(cls, args, this_class ? cls : new.target)
+        }
+    }
+    result[cls.name].prototype = cls.prototype
+    // fix default tag for toString, e.g. [object Action] instead of [object Object]
+    cls.prototype[Symbol.toStringTag] = cls.name
+    return result[cls.name]
+}
+
+function _alias(object, from, to) {
+    try {
+        let name = object.constructor.name
+        Object.defineProperty(object, from, {
+            value: util.deprecate(object[to], sub('%s.%s() is renamed to %s.%s()',
+                name, from, name, to)),
+            enumerable: false
+        })
+    } catch {}
+}
+
+// decorator that allows snake_case class methods to be called with camelCase and vice versa
+function _camelcase_alias(_class) {
+    for (let name of Object.getOwnPropertyNames(_class.prototype)) {
+        let camelcase = name.replace(/\w_[a-z]/g, s => s[0] + s[2].toUpperCase())
+        if (camelcase !== name) _alias(_class.prototype, camelcase, name)
+    }
+    return _class
+}
+
+function _to_legacy_name(key) {
+    key = key.replace(/\w_[a-z]/g, s => s[0] + s[2].toUpperCase())
+    if (key === 'default') key = 'defaultValue'
+    if (key === 'const') key = 'constant'
+    return key
+}
+
+function _to_new_name(key) {
+    if (key === 'defaultValue') key = 'default'
+    if (key === 'constant') key = 'const'
+    key = key.replace(/[A-Z]/g, c => '_' + c.toLowerCase())
+    return key
+}
+
+// parse options
+let no_default = Symbol('no_default_value')
+function _parse_opts(args, descriptor) {
+    function get_name() {
+        let stack = new Error().stack.split('\n')
+            .map(x => x.match(/^    at (.*) \(.*\)$/))
+            .filter(Boolean)
+            .map(m => m[1])
+            .map(fn => fn.match(/[^ .]*$/)[0])
+
+        if (stack.length && stack[0] === get_name.name) stack.shift()
+        if (stack.length && stack[0] === _parse_opts.name) stack.shift()
+        return stack.length ? stack[0] : ''
+    }
+
+    args = Array.from(args)
+    let kwargs = {}
+    let result = []
+    let last_opt = args.length && args[args.length - 1]
+
+    if (typeof last_opt === 'object' && last_opt !== null && !Array.isArray(last_opt) &&
+        (!last_opt.constructor || last_opt.constructor.name === 'Object')) {
+        kwargs = Object.assign({}, args.pop())
+    }
+
+    // LEGACY (v1 compatibility): camelcase
+    let renames = []
+    for (let key of Object.keys(descriptor)) {
+        let old_name = _to_legacy_name(key)
+        if (old_name !== key && (old_name in kwargs)) {
+            if (key in kwargs) {
+                // default and defaultValue specified at the same time, happens often in old tests
+                //throw new TypeError(sub('%s() got multiple values for argument %r', get_name(), key))
+            } else {
+                kwargs[key] = kwargs[old_name]
+            }
+            renames.push([ old_name, key ])
+            delete kwargs[old_name]
+        }
+    }
+    if (renames.length) {
+        let name = get_name()
+        deprecate('camelcase_' + name, sub('%s(): following options are renamed: %s',
+            name, renames.map(([ a, b ]) => sub('%r -> %r', a, b))))
+    }
+    // end
+
+    let missing_positionals = []
+    let positional_count = args.length
+
+    for (let [ key, def ] of Object.entries(descriptor)) {
+        if (key[0] === '*') {
+            if (key.length > 0 && key[1] === '*') {
+                // LEGACY (v1 compatibility): camelcase
+                let renames = []
+                for (let key of Object.keys(kwargs)) {
+                    let new_name = _to_new_name(key)
+                    if (new_name !== key && (key in kwargs)) {
+                        if (new_name in kwargs) {
+                            // default and defaultValue specified at the same time, happens often in old tests
+                            //throw new TypeError(sub('%s() got multiple values for argument %r', get_name(), new_name))
+                        } else {
+                            kwargs[new_name] = kwargs[key]
+                        }
+                        renames.push([ key, new_name ])
+                        delete kwargs[key]
+                    }
+                }
+                if (renames.length) {
+                    let name = get_name()
+                    deprecate('camelcase_' + name, sub('%s(): following options are renamed: %s',
+                        name, renames.map(([ a, b ]) => sub('%r -> %r', a, b))))
+                }
+                // end
+                result.push(kwargs)
+                kwargs = {}
+            } else {
+                result.push(args)
+                args = []
+            }
+        } else if (key in kwargs && args.length > 0) {
+            throw new TypeError(sub('%s() got multiple values for argument %r', get_name(), key))
+        } else if (key in kwargs) {
+            result.push(kwargs[key])
+            delete kwargs[key]
+        } else if (args.length > 0) {
+            result.push(args.shift())
+        } else if (def !== no_default) {
+            result.push(def)
+        } else {
+            missing_positionals.push(key)
+        }
+    }
+
+    if (Object.keys(kwargs).length) {
+        throw new TypeError(sub('%s() got an unexpected keyword argument %r',
+            get_name(), Object.keys(kwargs)[0]))
+    }
+
+    if (args.length) {
+        let from = Object.entries(descriptor).filter(([ k, v ]) => k[0] !== '*' && v !== no_default).length
+        let to = Object.entries(descriptor).filter(([ k ]) => k[0] !== '*').length
+        throw new TypeError(sub('%s() takes %s positional argument%s but %s %s given',
+            get_name(),
+            from === to ? sub('from %s to %s', from, to) : to,
+            from === to && to === 1 ? '' : 's',
+            positional_count,
+            positional_count === 1 ? 'was' : 'were'))
+    }
+
+    if (missing_positionals.length) {
+        let strs = missing_positionals.map(repr)
+        if (strs.length > 1) strs[strs.length - 1] = 'and ' + strs[strs.length - 1]
+        let str_joined = strs.join(strs.length === 2 ? '' : ', ')
+        throw new TypeError(sub('%s() missing %i required positional argument%s: %s',
+            get_name(), strs.length, strs.length === 1 ? '' : 's', str_joined))
+    }
+
+    return result
+}
+
+let _deprecations = {}
+function deprecate(id, string) {
+    _deprecations[id] = _deprecations[id] || util.deprecate(() => {}, string)
+    _deprecations[id]()
+}
+
+
+// =============================
+// Utility functions and classes
+// =============================
+function _AttributeHolder(cls = Object) {
+    /*
+     *  Abstract base class that provides __repr__.
+     *
+     *  The __repr__ method returns a string in the format::
+     *      ClassName(attr=name, attr=name, ...)
+     *  The attributes are determined either by a class-level attribute,
+     *  '_kwarg_names', or by inspecting the instance __dict__.
+     */
+
+    return class _AttributeHolder extends cls {
+        [util.inspect.custom]() {
+            let type_name = this.constructor.name
+            let arg_strings = []
+            let star_args = {}
+            for (let arg of this._get_args()) {
+                arg_strings.push(repr(arg))
+            }
+            for (let [ name, value ] of this._get_kwargs()) {
+                if (/^[a-z_][a-z0-9_$]*$/i.test(name)) {
+                    arg_strings.push(sub('%s=%r', name, value))
+                } else {
+                    star_args[name] = value
+                }
+            }
+            if (Object.keys(star_args).length) {
+                arg_strings.push(sub('**%s', repr(star_args)))
+            }
+            return sub('%s(%s)', type_name, arg_strings.join(', '))
+        }
+
+        toString() {
+            return this[util.inspect.custom]()
+        }
+
+        _get_kwargs() {
+            return Object.entries(this)
+        }
+
+        _get_args() {
+            return []
+        }
+    }
+}
+
+
+function _copy_items(items) {
+    if (items === undefined) {
+        return []
+    }
+    return items.slice(0)
+}
+
+
+// ===============
+// Formatting Help
+// ===============
+const HelpFormatter = _camelcase_alias(_callable(class HelpFormatter {
+    /*
+     *  Formatter for generating usage messages and argument help strings.
+     *
+     *  Only the name of this class is considered a public API. All the methods
+     *  provided by the class are considered an implementation detail.
+     */
+
+    constructor() {
+        let [
+            prog,
+            indent_increment,
+            max_help_position,
+            width
+        ] = _parse_opts(arguments, {
+            prog: no_default,
+            indent_increment: 2,
+            max_help_position: 24,
+            width: undefined
+        })
+
+        // default setting for width
+        if (width === undefined) {
+            width = get_terminal_size().columns
+            width -= 2
+        }
+
+        this._prog = prog
+        this._indent_increment = indent_increment
+        this._max_help_position = Math.min(max_help_position,
+                                      Math.max(width - 20, indent_increment * 2))
+        this._width = width
+
+        this._current_indent = 0
+        this._level = 0
+        this._action_max_length = 0
+
+        this._root_section = this._Section(this, undefined)
+        this._current_section = this._root_section
+
+        this._whitespace_matcher = /[ \t\n\r\f\v]+/g // equivalent to python /\s+/ with ASCII flag
+        this._long_break_matcher = /\n\n\n+/g
+    }
+
+    // ===============================
+    // Section and indentation methods
+    // ===============================
+    _indent() {
+        this._current_indent += this._indent_increment
+        this._level += 1
+    }
+
+    _dedent() {
+        this._current_indent -= this._indent_increment
+        assert(this._current_indent >= 0, 'Indent decreased below 0.')
+        this._level -= 1
+    }
+
+    _add_item(func, args) {
+        this._current_section.items.push([ func, args ])
+    }
+
+    // ========================
+    // Message building methods
+    // ========================
+    start_section(heading) {
+        this._indent()
+        let section = this._Section(this, this._current_section, heading)
+        this._add_item(section.format_help.bind(section), [])
+        this._current_section = section
+    }
+
+    end_section() {
+        this._current_section = this._current_section.parent
+        this._dedent()
+    }
+
+    add_text(text) {
+        if (text !== SUPPRESS && text !== undefined) {
+            this._add_item(this._format_text.bind(this), [text])
+        }
+    }
+
+    add_usage(usage, actions, groups, prefix = undefined) {
+        if (usage !== SUPPRESS) {
+            let args = [ usage, actions, groups, prefix ]
+            this._add_item(this._format_usage.bind(this), args)
+        }
+    }
+
+    add_argument(action) {
+        if (action.help !== SUPPRESS) {
+
+            // find all invocations
+            let invocations = [this._format_action_invocation(action)]
+            for (let subaction of this._iter_indented_subactions(action)) {
+                invocations.push(this._format_action_invocation(subaction))
+            }
+
+            // update the maximum item length
+            let invocation_length = Math.max(...invocations.map(invocation => invocation.length))
+            let action_length = invocation_length + this._current_indent
+            this._action_max_length = Math.max(this._action_max_length,
+                                               action_length)
+
+            // add the item to the list
+            this._add_item(this._format_action.bind(this), [action])
+        }
+    }
+
+    add_arguments(actions) {
+        for (let action of actions) {
+            this.add_argument(action)
+        }
+    }
+
+    // =======================
+    // Help-formatting methods
+    // =======================
+    format_help() {
+        let help = this._root_section.format_help()
+        if (help) {
+            help = help.replace(this._long_break_matcher, '\n\n')
+            help = help.replace(/^\n+|\n+$/g, '') + '\n'
+        }
+        return help
+    }
+
+    _join_parts(part_strings) {
+        return part_strings.filter(part => part && part !== SUPPRESS).join('')
+    }
+
+    _format_usage(usage, actions, groups, prefix) {
+        if (prefix === undefined) {
+            prefix = 'usage: '
+        }
+
+        // if usage is specified, use that
+        if (usage !== undefined) {
+            usage = sub(usage, { prog: this._prog })
+
+        // if no optionals or positionals are available, usage is just prog
+        } else if (usage === undefined && !actions.length) {
+            usage = sub('%(prog)s', { prog: this._prog })
+
+        // if optionals and positionals are available, calculate usage
+        } else if (usage === undefined) {
+            let prog = sub('%(prog)s', { prog: this._prog })
+
+            // split optionals from positionals
+            let optionals = []
+            let positionals = []
+            for (let action of actions) {
+                if (action.option_strings.length) {
+                    optionals.push(action)
+                } else {
+                    positionals.push(action)
+                }
+            }
+
+            // build full usage string
+            let action_usage = this._format_actions_usage([].concat(optionals).concat(positionals), groups)
+            usage = [ prog, action_usage ].map(String).join(' ')
+
+            // wrap the usage parts if it's too long
+            let text_width = this._width - this._current_indent
+            if (prefix.length + usage.length > text_width) {
+
+                // break usage into wrappable parts
+                let part_regexp = /\(.*?\)+(?=\s|$)|\[.*?\]+(?=\s|$)|\S+/g
+                let opt_usage = this._format_actions_usage(optionals, groups)
+                let pos_usage = this._format_actions_usage(positionals, groups)
+                let opt_parts = opt_usage.match(part_regexp) || []
+                let pos_parts = pos_usage.match(part_regexp) || []
+                assert(opt_parts.join(' ') === opt_usage)
+                assert(pos_parts.join(' ') === pos_usage)
+
+                // helper for wrapping lines
+                let get_lines = (parts, indent, prefix = undefined) => {
+                    let lines = []
+                    let line = []
+                    let line_len
+                    if (prefix !== undefined) {
+                        line_len = prefix.length - 1
+                    } else {
+                        line_len = indent.length - 1
+                    }
+                    for (let part of parts) {
+                        if (line_len + 1 + part.length > text_width && line) {
+                            lines.push(indent + line.join(' '))
+                            line = []
+                            line_len = indent.length - 1
+                        }
+                        line.push(part)
+                        line_len += part.length + 1
+                    }
+                    if (line.length) {
+                        lines.push(indent + line.join(' '))
+                    }
+                    if (prefix !== undefined) {
+                        lines[0] = lines[0].slice(indent.length)
+                    }
+                    return lines
+                }
+
+                let lines
+
+                // if prog is short, follow it with optionals or positionals
+                if (prefix.length + prog.length <= 0.75 * text_width) {
+                    let indent = ' '.repeat(prefix.length + prog.length + 1)
+                    if (opt_parts.length) {
+                        lines = get_lines([prog].concat(opt_parts), indent, prefix)
+                        lines = lines.concat(get_lines(pos_parts, indent))
+                    } else if (pos_parts.length) {
+                        lines = get_lines([prog].concat(pos_parts), indent, prefix)
+                    } else {
+                        lines = [prog]
+                    }
+
+                // if prog is long, put it on its own line
+                } else {
+                    let indent = ' '.repeat(prefix.length)
+                    let parts = [].concat(opt_parts).concat(pos_parts)
+                    lines = get_lines(parts, indent)
+                    if (lines.length > 1) {
+                        lines = []
+                        lines = lines.concat(get_lines(opt_parts, indent))
+                        lines = lines.concat(get_lines(pos_parts, indent))
+                    }
+                    lines = [prog].concat(lines)
+                }
+
+                // join lines into usage
+                usage = lines.join('\n')
+            }
+        }
+
+        // prefix with 'usage:'
+        return sub('%s%s\n\n', prefix, usage)
+    }
+
+    _format_actions_usage(actions, groups) {
+        // find group indices and identify actions in groups
+        let group_actions = new Set()
+        let inserts = {}
+        for (let group of groups) {
+            let start = actions.indexOf(group._group_actions[0])
+            if (start === -1) {
+                continue
+            } else {
+                let end = start + group._group_actions.length
+                if (_array_equal(actions.slice(start, end), group._group_actions)) {
+                    for (let action of group._group_actions) {
+                        group_actions.add(action)
+                    }
+                    if (!group.required) {
+                        if (start in inserts) {
+                            inserts[start] += ' ['
+                        } else {
+                            inserts[start] = '['
+                        }
+                        if (end in inserts) {
+                            inserts[end] += ']'
+                        } else {
+                            inserts[end] = ']'
+                        }
+                    } else {
+                        if (start in inserts) {
+                            inserts[start] += ' ('
+                        } else {
+                            inserts[start] = '('
+                        }
+                        if (end in inserts) {
+                            inserts[end] += ')'
+                        } else {
+                            inserts[end] = ')'
+                        }
+                    }
+                    for (let i of range(start + 1, end)) {
+                        inserts[i] = '|'
+                    }
+                }
+            }
+        }
+
+        // collect all actions format strings
+        let parts = []
+        for (let [ i, action ] of Object.entries(actions)) {
+
+            // suppressed arguments are marked with None
+            // remove | separators for suppressed arguments
+            if (action.help === SUPPRESS) {
+                parts.push(undefined)
+                if (inserts[+i] === '|') {
+                    delete inserts[+i]
+                } else if (inserts[+i + 1] === '|') {
+                    delete inserts[+i + 1]
+                }
+
+            // produce all arg strings
+            } else if (!action.option_strings.length) {
+                let default_value = this._get_default_metavar_for_positional(action)
+                let part = this._format_args(action, default_value)
+
+                // if it's in a group, strip the outer []
+                if (group_actions.has(action)) {
+                    if (part[0] === '[' && part[part.length - 1] === ']') {
+                        part = part.slice(1, -1)
+                    }
+                }
+
+                // add the action string to the list
+                parts.push(part)
+
+            // produce the first way to invoke the option in brackets
+            } else {
+                let option_string = action.option_strings[0]
+                let part
+
+                // if the Optional doesn't take a value, format is:
+                //    -s or --long
+                if (action.nargs === 0) {
+                    part = action.format_usage()
+
+                // if the Optional takes a value, format is:
+                //    -s ARGS or --long ARGS
+                } else {
+                    let default_value = this._get_default_metavar_for_optional(action)
+                    let args_string = this._format_args(action, default_value)
+                    part = sub('%s %s', option_string, args_string)
+                }
+
+                // make it look optional if it's not required or in a group
+                if (!action.required && !group_actions.has(action)) {
+                    part = sub('[%s]', part)
+                }
+
+                // add the action string to the list
+                parts.push(part)
+            }
+        }
+
+        // insert things at the necessary indices
+        for (let i of Object.keys(inserts).map(Number).sort((a, b) => b - a)) {
+            parts.splice(+i, 0, inserts[+i])
+        }
+
+        // join all the action items with spaces
+        let text = parts.filter(Boolean).join(' ')
+
+        // clean up separators for mutually exclusive groups
+        text = text.replace(/([\[(]) /g, '$1')
+        text = text.replace(/ ([\])])/g, '$1')
+        text = text.replace(/[\[(] *[\])]/g, '')
+        text = text.replace(/\(([^|]*)\)/g, '$1', text)
+        text = text.trim()
+
+        // return the text
+        return text
+    }
+
+    _format_text(text) {
+        if (text.includes('%(prog)')) {
+            text = sub(text, { prog: this._prog })
+        }
+        let text_width = Math.max(this._width - this._current_indent, 11)
+        let indent = ' '.repeat(this._current_indent)
+        return this._fill_text(text, text_width, indent) + '\n\n'
+    }
+
+    _format_action(action) {
+        // determine the required width and the entry label
+        let help_position = Math.min(this._action_max_length + 2,
+                                     this._max_help_position)
+        let help_width = Math.max(this._width - help_position, 11)
+        let action_width = help_position - this._current_indent - 2
+        let action_header = this._format_action_invocation(action)
+        let indent_first
+
+        // no help; start on same line and add a final newline
+        if (!action.help) {
+            let tup = [ this._current_indent, '', action_header ]
+            action_header = sub('%*s%s\n', ...tup)
+
+        // short action name; start on the same line and pad two spaces
+        } else if (action_header.length <= action_width) {
+            let tup = [ this._current_indent, '', action_width, action_header ]
+            action_header = sub('%*s%-*s  ', ...tup)
+            indent_first = 0
+
+        // long action name; start on the next line
+        } else {
+            let tup = [ this._current_indent, '', action_header ]
+            action_header = sub('%*s%s\n', ...tup)
+            indent_first = help_position
+        }
+
+        // collect the pieces of the action help
+        let parts = [action_header]
+
+        // if there was help for the action, add lines of help text
+        if (action.help) {
+            let help_text = this._expand_help(action)
+            let help_lines = this._split_lines(help_text, help_width)
+            parts.push(sub('%*s%s\n', indent_first, '', help_lines[0]))
+            for (let line of help_lines.slice(1)) {
+                parts.push(sub('%*s%s\n', help_position, '', line))
+            }
+
+        // or add a newline if the description doesn't end with one
+        } else if (!action_header.endsWith('\n')) {
+            parts.push('\n')
+        }
+
+        // if there are any sub-actions, add their help as well
+        for (let subaction of this._iter_indented_subactions(action)) {
+            parts.push(this._format_action(subaction))
+        }
+
+        // return a single string
+        return this._join_parts(parts)
+    }
+
+    _format_action_invocation(action) {
+        if (!action.option_strings.length) {
+            let default_value = this._get_default_metavar_for_positional(action)
+            let metavar = this._metavar_formatter(action, default_value)(1)[0]
+            return metavar
+
+        } else {
+            let parts = []
+
+            // if the Optional doesn't take a value, format is:
+            //    -s, --long
+            if (action.nargs === 0) {
+                parts = parts.concat(action.option_strings)
+
+            // if the Optional takes a value, format is:
+            //    -s ARGS, --long ARGS
+            } else {
+                let default_value = this._get_default_metavar_for_optional(action)
+                let args_string = this._format_args(action, default_value)
+                for (let option_string of action.option_strings) {
+                    parts.push(sub('%s %s', option_string, args_string))
+                }
+            }
+
+            return parts.join(', ')
+        }
+    }
+
+    _metavar_formatter(action, default_metavar) {
+        let result
+        if (action.metavar !== undefined) {
+            result = action.metavar
+        } else if (action.choices !== undefined) {
+            let choice_strs = _choices_to_array(action.choices).map(String)
+            result = sub('{%s}', choice_strs.join(','))
+        } else {
+            result = default_metavar
+        }
+
+        function format(tuple_size) {
+            if (Array.isArray(result)) {
+                return result
+            } else {
+                return Array(tuple_size).fill(result)
+            }
+        }
+        return format
+    }
+
+    _format_args(action, default_metavar) {
+        let get_metavar = this._metavar_formatter(action, default_metavar)
+        let result
+        if (action.nargs === undefined) {
+            result = sub('%s', ...get_metavar(1))
+        } else if (action.nargs === OPTIONAL) {
+            result = sub('[%s]', ...get_metavar(1))
+        } else if (action.nargs === ZERO_OR_MORE) {
+            let metavar = get_metavar(1)
+            if (metavar.length === 2) {
+                result = sub('[%s [%s ...]]', ...metavar)
+            } else {
+                result = sub('[%s ...]', ...metavar)
+            }
+        } else if (action.nargs === ONE_OR_MORE) {
+            result = sub('%s [%s ...]', ...get_metavar(2))
+        } else if (action.nargs === REMAINDER) {
+            result = '...'
+        } else if (action.nargs === PARSER) {
+            result = sub('%s ...', ...get_metavar(1))
+        } else if (action.nargs === SUPPRESS) {
+            result = ''
+        } else {
+            let formats
+            try {
+                formats = range(action.nargs).map(() => '%s')
+            } catch (err) {
+                throw new TypeError('invalid nargs value')
+            }
+            result = sub(formats.join(' '), ...get_metavar(action.nargs))
+        }
+        return result
+    }
+
+    _expand_help(action) {
+        let params = Object.assign({ prog: this._prog }, action)
+        for (let name of Object.keys(params)) {
+            if (params[name] === SUPPRESS) {
+                delete params[name]
+            }
+        }
+        for (let name of Object.keys(params)) {
+            if (params[name] && params[name].name) {
+                params[name] = params[name].name
+            }
+        }
+        if (params.choices !== undefined) {
+            let choices_str = _choices_to_array(params.choices).map(String).join(', ')
+            params.choices = choices_str
+        }
+        // LEGACY (v1 compatibility): camelcase
+        for (let key of Object.keys(params)) {
+            let old_name = _to_legacy_name(key)
+            if (old_name !== key) {
+                params[old_name] = params[key]
+            }
+        }
+        // end
+        return sub(this._get_help_string(action), params)
+    }
+
+    * _iter_indented_subactions(action) {
+        if (typeof action._get_subactions === 'function') {
+            this._indent()
+            yield* action._get_subactions()
+            this._dedent()
+        }
+    }
+
+    _split_lines(text, width) {
+        text = text.replace(this._whitespace_matcher, ' ').trim()
+        // The textwrap module is used only for formatting help.
+        // Delay its import for speeding up the common usage of argparse.
+        let textwrap = require('./lib/textwrap')
+        return textwrap.wrap(text, { width })
+    }
+
+    _fill_text(text, width, indent) {
+        text = text.replace(this._whitespace_matcher, ' ').trim()
+        let textwrap = require('./lib/textwrap')
+        return textwrap.fill(text, { width,
+                                     initial_indent: indent,
+                                     subsequent_indent: indent })
+    }
+
+    _get_help_string(action) {
+        return action.help
+    }
+
+    _get_default_metavar_for_optional(action) {
+        return action.dest.toUpperCase()
+    }
+
+    _get_default_metavar_for_positional(action) {
+        return action.dest
+    }
+}))
+
+HelpFormatter.prototype._Section = _callable(class _Section {
+
+    constructor(formatter, parent, heading = undefined) {
+        this.formatter = formatter
+        this.parent = parent
+        this.heading = heading
+        this.items = []
+    }
+
+    format_help() {
+        // format the indented section
+        if (this.parent !== undefined) {
+            this.formatter._indent()
+        }
+        let item_help = this.formatter._join_parts(this.items.map(([ func, args ]) => func.apply(null, args)))
+        if (this.parent !== undefined) {
+            this.formatter._dedent()
+        }
+
+        // return nothing if the section was empty
+        if (!item_help) {
+            return ''
+        }
+
+        // add the heading if the section was non-empty
+        let heading
+        if (this.heading !== SUPPRESS && this.heading !== undefined) {
+            let current_indent = this.formatter._current_indent
+            heading = sub('%*s%s:\n', current_indent, '', this.heading)
+        } else {
+            heading = ''
+        }
+
+        // join the section-initial newline, the heading and the help
+        return this.formatter._join_parts(['\n', heading, item_help, '\n'])
+    }
+})
+
+
+const RawDescriptionHelpFormatter = _camelcase_alias(_callable(class RawDescriptionHelpFormatter extends HelpFormatter {
+    /*
+     *  Help message formatter which retains any formatting in descriptions.
+     *
+     *  Only the name of this class is considered a public API. All the methods
+     *  provided by the class are considered an implementation detail.
+     */
+
+    _fill_text(text, width, indent) {
+        return splitlines(text, true).map(line => indent + line).join('')
+    }
+}))
+
+
+const RawTextHelpFormatter = _camelcase_alias(_callable(class RawTextHelpFormatter extends RawDescriptionHelpFormatter {
+    /*
+     *  Help message formatter which retains formatting of all help text.
+     *
+     *  Only the name of this class is considered a public API. All the methods
+     *  provided by the class are considered an implementation detail.
+     */
+
+    _split_lines(text/*, width*/) {
+        return splitlines(text)
+    }
+}))
+
+
+const ArgumentDefaultsHelpFormatter = _camelcase_alias(_callable(class ArgumentDefaultsHelpFormatter extends HelpFormatter {
+    /*
+     *  Help message formatter which adds default values to argument help.
+     *
+     *  Only the name of this class is considered a public API. All the methods
+     *  provided by the class are considered an implementation detail.
+     */
+
+    _get_help_string(action) {
+        let help = action.help
+        // LEGACY (v1 compatibility): additional check for defaultValue needed
+        if (!action.help.includes('%(default)') && !action.help.includes('%(defaultValue)')) {
+            if (action.default !== SUPPRESS) {
+                let defaulting_nargs = [OPTIONAL, ZERO_OR_MORE]
+                if (action.option_strings.length || defaulting_nargs.includes(action.nargs)) {
+                    help += ' (default: %(default)s)'
+                }
+            }
+        }
+        return help
+    }
+}))
+
+
+const MetavarTypeHelpFormatter = _camelcase_alias(_callable(class MetavarTypeHelpFormatter extends HelpFormatter {
+    /*
+     *  Help message formatter which uses the argument 'type' as the default
+     *  metavar value (instead of the argument 'dest')
+     *
+     *  Only the name of this class is considered a public API. All the methods
+     *  provided by the class are considered an implementation detail.
+     */
+
+    _get_default_metavar_for_optional(action) {
+        return typeof action.type === 'function' ? action.type.name : action.type
+    }
+
+    _get_default_metavar_for_positional(action) {
+        return typeof action.type === 'function' ? action.type.name : action.type
+    }
+}))
+
+
+// =====================
+// Options and Arguments
+// =====================
+function _get_action_name(argument) {
+    if (argument === undefined) {
+        return undefined
+    } else if (argument.option_strings.length) {
+        return argument.option_strings.join('/')
+    } else if (![ undefined, SUPPRESS ].includes(argument.metavar)) {
+        return argument.metavar
+    } else if (![ undefined, SUPPRESS ].includes(argument.dest)) {
+        return argument.dest
+    } else {
+        return undefined
+    }
+}
+
+
+const ArgumentError = _callable(class ArgumentError extends Error {
+    /*
+     *  An error from creating or using an argument (optional or positional).
+     *
+     *  The string value of this exception is the message, augmented with
+     *  information about the argument that caused it.
+     */
+
+    constructor(argument, message) {
+        super()
+        this.name = 'ArgumentError'
+        this._argument_name = _get_action_name(argument)
+        this._message = message
+        this.message = this.str()
+    }
+
+    str() {
+        let format
+        if (this._argument_name === undefined) {
+            format = '%(message)s'
+        } else {
+            format = 'argument %(argument_name)s: %(message)s'
+        }
+        return sub(format, { message: this._message,
+                             argument_name: this._argument_name })
+    }
+})
+
+
+const ArgumentTypeError = _callable(class ArgumentTypeError extends Error {
+    /*
+     * An error from trying to convert a command line string to a type.
+     */
+
+    constructor(message) {
+        super(message)
+        this.name = 'ArgumentTypeError'
+    }
+})
+
+
+// ==============
+// Action classes
+// ==============
+const Action = _camelcase_alias(_callable(class Action extends _AttributeHolder(Function) {
+    /*
+     *  Information about how to convert command line strings to Python objects.
+     *
+     *  Action objects are used by an ArgumentParser to represent the information
+     *  needed to parse a single argument from one or more strings from the
+     *  command line. The keyword arguments to the Action constructor are also
+     *  all attributes of Action instances.
+     *
+     *  Keyword Arguments:
+     *
+     *      - option_strings -- A list of command-line option strings which
+     *          should be associated with this action.
+     *
+     *      - dest -- The name of the attribute to hold the created object(s)
+     *
+     *      - nargs -- The number of command-line arguments that should be
+     *          consumed. By default, one argument will be consumed and a single
+     *          value will be produced.  Other values include:
+     *              - N (an integer) consumes N arguments (and produces a list)
+     *              - '?' consumes zero or one arguments
+     *              - '*' consumes zero or more arguments (and produces a list)
+     *              - '+' consumes one or more arguments (and produces a list)
+     *          Note that the difference between the default and nargs=1 is that
+     *          with the default, a single value will be produced, while with
+     *          nargs=1, a list containing a single value will be produced.
+     *
+     *      - const -- The value to be produced if the option is specified and the
+     *          option uses an action that takes no values.
+     *
+     *      - default -- The value to be produced if the option is not specified.
+     *
+     *      - type -- A callable that accepts a single string argument, and
+     *          returns the converted value.  The standard Python types str, int,
+     *          float, and complex are useful examples of such callables.  If None,
+     *          str is used.
+     *
+     *      - choices -- A container of values that should be allowed. If not None,
+     *          after a command-line argument has been converted to the appropriate
+     *          type, an exception will be raised if it is not a member of this
+     *          collection.
+     *
+     *      - required -- True if the action must always be specified at the
+     *          command line. This is only meaningful for optional command-line
+     *          arguments.
+     *
+     *      - help -- The help string describing the argument.
+     *
+     *      - metavar -- The name to be used for the option's argument with the
+     *          help string. If None, the 'dest' value will be used as the name.
+     */
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            nargs,
+            const_value,
+            default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            nargs: undefined,
+            const: undefined,
+            default: undefined,
+            type: undefined,
+            choices: undefined,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        // when this class is called as a function, redirect it to .call() method of itself
+        super('return arguments.callee.call.apply(arguments.callee, arguments)')
+
+        this.option_strings = option_strings
+        this.dest = dest
+        this.nargs = nargs
+        this.const = const_value
+        this.default = default_value
+        this.type = type
+        this.choices = choices
+        this.required = required
+        this.help = help
+        this.metavar = metavar
+    }
+
+    _get_kwargs() {
+        let names = [
+            'option_strings',
+            'dest',
+            'nargs',
+            'const',
+            'default',
+            'type',
+            'choices',
+            'help',
+            'metavar'
+        ]
+        return names.map(name => [ name, getattr(this, name) ])
+    }
+
+    format_usage() {
+        return this.option_strings[0]
+    }
+
+    call(/*parser, namespace, values, option_string = undefined*/) {
+        throw new Error('.call() not defined')
+    }
+}))
+
+
+const BooleanOptionalAction = _camelcase_alias(_callable(class BooleanOptionalAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            default: undefined,
+            type: undefined,
+            choices: undefined,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        let _option_strings = []
+        for (let option_string of option_strings) {
+            _option_strings.push(option_string)
+
+            if (option_string.startsWith('--')) {
+                option_string = '--no-' + option_string.slice(2)
+                _option_strings.push(option_string)
+            }
+        }
+
+        if (help !== undefined && default_value !== undefined) {
+            help += ` (default: ${default_value})`
+        }
+
+        super({
+            option_strings: _option_strings,
+            dest,
+            nargs: 0,
+            default: default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        })
+    }
+
+    call(parser, namespace, values, option_string = undefined) {
+        if (this.option_strings.includes(option_string)) {
+            setattr(namespace, this.dest, !option_string.startsWith('--no-'))
+        }
+    }
+
+    format_usage() {
+        return this.option_strings.join(' | ')
+    }
+}))
+
+
+const _StoreAction = _callable(class _StoreAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            nargs,
+            const_value,
+            default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            nargs: undefined,
+            const: undefined,
+            default: undefined,
+            type: undefined,
+            choices: undefined,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        if (nargs === 0) {
+            throw new TypeError('nargs for store actions must be != 0; if you ' +
+                        'have nothing to store, actions such as store ' +
+                        'true or store const may be more appropriate')
+        }
+        if (const_value !== undefined && nargs !== OPTIONAL) {
+            throw new TypeError(sub('nargs must be %r to supply const', OPTIONAL))
+        }
+        super({
+            option_strings,
+            dest,
+            nargs,
+            const: const_value,
+            default: default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        })
+    }
+
+    call(parser, namespace, values/*, option_string = undefined*/) {
+        setattr(namespace, this.dest, values)
+    }
+})
+
+
+const _StoreConstAction = _callable(class _StoreConstAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            const_value,
+            default_value,
+            required,
+            help
+            //, metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            const: no_default,
+            default: undefined,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        super({
+            option_strings,
+            dest,
+            nargs: 0,
+            const: const_value,
+            default: default_value,
+            required,
+            help
+        })
+    }
+
+    call(parser, namespace/*, values, option_string = undefined*/) {
+        setattr(namespace, this.dest, this.const)
+    }
+})
+
+
+const _StoreTrueAction = _callable(class _StoreTrueAction extends _StoreConstAction {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            default_value,
+            required,
+            help
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            default: false,
+            required: false,
+            help: undefined
+        })
+
+        super({
+            option_strings,
+            dest,
+            const: true,
+            default: default_value,
+            required,
+            help
+        })
+    }
+})
+
+
+const _StoreFalseAction = _callable(class _StoreFalseAction extends _StoreConstAction {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            default_value,
+            required,
+            help
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            default: true,
+            required: false,
+            help: undefined
+        })
+
+        super({
+            option_strings,
+            dest,
+            const: false,
+            default: default_value,
+            required,
+            help
+        })
+    }
+})
+
+
+const _AppendAction = _callable(class _AppendAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            nargs,
+            const_value,
+            default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            nargs: undefined,
+            const: undefined,
+            default: undefined,
+            type: undefined,
+            choices: undefined,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        if (nargs === 0) {
+            throw new TypeError('nargs for append actions must be != 0; if arg ' +
+                        'strings are not supplying the value to append, ' +
+                        'the append const action may be more appropriate')
+        }
+        if (const_value !== undefined && nargs !== OPTIONAL) {
+            throw new TypeError(sub('nargs must be %r to supply const', OPTIONAL))
+        }
+        super({
+            option_strings,
+            dest,
+            nargs,
+            const: const_value,
+            default: default_value,
+            type,
+            choices,
+            required,
+            help,
+            metavar
+        })
+    }
+
+    call(parser, namespace, values/*, option_string = undefined*/) {
+        let items = getattr(namespace, this.dest, undefined)
+        items = _copy_items(items)
+        items.push(values)
+        setattr(namespace, this.dest, items)
+    }
+})
+
+
+const _AppendConstAction = _callable(class _AppendConstAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            const_value,
+            default_value,
+            required,
+            help,
+            metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            const: no_default,
+            default: undefined,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        super({
+            option_strings,
+            dest,
+            nargs: 0,
+            const: const_value,
+            default: default_value,
+            required,
+            help,
+            metavar
+        })
+    }
+
+    call(parser, namespace/*, values, option_string = undefined*/) {
+        let items = getattr(namespace, this.dest, undefined)
+        items = _copy_items(items)
+        items.push(this.const)
+        setattr(namespace, this.dest, items)
+    }
+})
+
+
+const _CountAction = _callable(class _CountAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            default_value,
+            required,
+            help
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: no_default,
+            default: undefined,
+            required: false,
+            help: undefined
+        })
+
+        super({
+            option_strings,
+            dest,
+            nargs: 0,
+            default: default_value,
+            required,
+            help
+        })
+    }
+
+    call(parser, namespace/*, values, option_string = undefined*/) {
+        let count = getattr(namespace, this.dest, undefined)
+        if (count === undefined) {
+            count = 0
+        }
+        setattr(namespace, this.dest, count + 1)
+    }
+})
+
+
+const _HelpAction = _callable(class _HelpAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            dest,
+            default_value,
+            help
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            dest: SUPPRESS,
+            default: SUPPRESS,
+            help: undefined
+        })
+
+        super({
+            option_strings,
+            dest,
+            default: default_value,
+            nargs: 0,
+            help
+        })
+    }
+
+    call(parser/*, namespace, values, option_string = undefined*/) {
+        parser.print_help()
+        parser.exit()
+    }
+})
+
+
+const _VersionAction = _callable(class _VersionAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            version,
+            dest,
+            default_value,
+            help
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            version: undefined,
+            dest: SUPPRESS,
+            default: SUPPRESS,
+            help: "show program's version number and exit"
+        })
+
+        super({
+            option_strings,
+            dest,
+            default: default_value,
+            nargs: 0,
+            help
+        })
+        this.version = version
+    }
+
+    call(parser/*, namespace, values, option_string = undefined*/) {
+        let version = this.version
+        if (version === undefined) {
+            version = parser.version
+        }
+        let formatter = parser._get_formatter()
+        formatter.add_text(version)
+        parser._print_message(formatter.format_help(), process.stdout)
+        parser.exit()
+    }
+})
+
+
+const _SubParsersAction = _camelcase_alias(_callable(class _SubParsersAction extends Action {
+
+    constructor() {
+        let [
+            option_strings,
+            prog,
+            parser_class,
+            dest,
+            required,
+            help,
+            metavar
+        ] = _parse_opts(arguments, {
+            option_strings: no_default,
+            prog: no_default,
+            parser_class: no_default,
+            dest: SUPPRESS,
+            required: false,
+            help: undefined,
+            metavar: undefined
+        })
+
+        let name_parser_map = {}
+
+        super({
+            option_strings,
+            dest,
+            nargs: PARSER,
+            choices: name_parser_map,
+            required,
+            help,
+            metavar
+        })
+
+        this._prog_prefix = prog
+        this._parser_class = parser_class
+        this._name_parser_map = name_parser_map
+        this._choices_actions = []
+    }
+
+    add_parser() {
+        let [
+            name,
+            kwargs
+        ] = _parse_opts(arguments, {
+            name: no_default,
+            '**kwargs': no_default
+        })
+
+        // set prog from the existing prefix
+        if (kwargs.prog === undefined) {
+            kwargs.prog = sub('%s %s', this._prog_prefix, name)
+        }
+
+        let aliases = getattr(kwargs, 'aliases', [])
+        delete kwargs.aliases
+
+        // create a pseudo-action to hold the choice help
+        if ('help' in kwargs) {
+            let help = kwargs.help
+            delete kwargs.help
+            let choice_action = this._ChoicesPseudoAction(name, aliases, help)
+            this._choices_actions.push(choice_action)
+        }
+
+        // create the parser and add it to the map
+        let parser = new this._parser_class(kwargs)
+        this._name_parser_map[name] = parser
+
+        // make parser available under aliases also
+        for (let alias of aliases) {
+            this._name_parser_map[alias] = parser
+        }
+
+        return parser
+    }
+
+    _get_subactions() {
+        return this._choices_actions
+    }
+
+    call(parser, namespace, values/*, option_string = undefined*/) {
+        let parser_name = values[0]
+        let arg_strings = values.slice(1)
+
+        // set the parser name if requested
+        if (this.dest !== SUPPRESS) {
+            setattr(namespace, this.dest, parser_name)
+        }
+
+        // select the parser
+        if (hasattr(this._name_parser_map, parser_name)) {
+            parser = this._name_parser_map[parser_name]
+        } else {
+            let args = {parser_name,
+                        choices: this._name_parser_map.join(', ')}
+            let msg = sub('unknown parser %(parser_name)r (choices: %(choices)s)', args)
+            throw new ArgumentError(this, msg)
+        }
+
+        // parse all the remaining options into the namespace
+        // store any unrecognized options on the object, so that the top
+        // level parser can decide what to do with them
+
+        // In case this subparser defines new defaults, we parse them
+        // in a new namespace object and then update the original
+        // namespace for the relevant parts.
+        let subnamespace
+        [ subnamespace, arg_strings ] = parser.parse_known_args(arg_strings, undefined)
+        for (let [ key, value ] of Object.entries(subnamespace)) {
+            setattr(namespace, key, value)
+        }
+
+        if (arg_strings.length) {
+            setdefault(namespace, _UNRECOGNIZED_ARGS_ATTR, [])
+            getattr(namespace, _UNRECOGNIZED_ARGS_ATTR).push(...arg_strings)
+        }
+    }
+}))
+
+
+_SubParsersAction.prototype._ChoicesPseudoAction = _callable(class _ChoicesPseudoAction extends Action {
+    constructor(name, aliases, help) {
+        let metavar = name, dest = name
+        if (aliases.length) {
+            metavar += sub(' (%s)', aliases.join(', '))
+        }
+        super({ option_strings: [], dest, help, metavar })
+    }
+})
+
+
+const _ExtendAction = _callable(class _ExtendAction extends _AppendAction {
+    call(parser, namespace, values/*, option_string = undefined*/) {
+        let items = getattr(namespace, this.dest, undefined)
+        items = _copy_items(items)
+        items = items.concat(values)
+        setattr(namespace, this.dest, items)
+    }
+})
+
+
+// ==============
+// Type classes
+// ==============
+const FileType = _callable(class FileType extends Function {
+    /*
+     *  Factory for creating file object types
+     *
+     *  Instances of FileType are typically passed as type= arguments to the
+     *  ArgumentParser add_argument() method.
+     *
+     *  Keyword Arguments:
+     *      - mode -- A string indicating how the file is to be opened. Accepts the
+     *          same values as the builtin open() function.
+     *      - bufsize -- The file's desired buffer size. Accepts the same values as
+     *          the builtin open() function.
+     *      - encoding -- The file's encoding. Accepts the same values as the
+     *          builtin open() function.
+     *      - errors -- A string indicating how encoding and decoding errors are to
+     *          be handled. Accepts the same value as the builtin open() function.
+     */
+
+    constructor() {
+        let [
+            flags,
+            encoding,
+            mode,
+            autoClose,
+            emitClose,
+            start,
+            end,
+            highWaterMark,
+            fs
+        ] = _parse_opts(arguments, {
+            flags: 'r',
+            encoding: undefined,
+            mode: undefined, // 0o666
+            autoClose: undefined, // true
+            emitClose: undefined, // false
+            start: undefined, // 0
+            end: undefined, // Infinity
+            highWaterMark: undefined, // 64 * 1024
+            fs: undefined
+        })
+
+        // when this class is called as a function, redirect it to .call() method of itself
+        super('return arguments.callee.call.apply(arguments.callee, arguments)')
+
+        Object.defineProperty(this, 'name', {
+            get() {
+                return sub('FileType(%r)', flags)
+            }
+        })
+        this._flags = flags
+        this._options = {}
+        if (encoding !== undefined) this._options.encoding = encoding
+        if (mode !== undefined) this._options.mode = mode
+        if (autoClose !== undefined) this._options.autoClose = autoClose
+        if (emitClose !== undefined) this._options.emitClose = emitClose
+        if (start !== undefined) this._options.start = start
+        if (end !== undefined) this._options.end = end
+        if (highWaterMark !== undefined) this._options.highWaterMark = highWaterMark
+        if (fs !== undefined) this._options.fs = fs
+    }
+
+    call(string) {
+        // the special argument "-" means sys.std{in,out}
+        if (string === '-') {
+            if (this._flags.includes('r')) {
+                return process.stdin
+            } else if (this._flags.includes('w')) {
+                return process.stdout
+            } else {
+                let msg = sub('argument "-" with mode %r', this._flags)
+                throw new TypeError(msg)
+            }
+        }
+
+        // all other arguments are used as file names
+        let fd
+        try {
+            fd = fs.openSync(string, this._flags, this._options.mode)
+        } catch (e) {
+            let args = { filename: string, error: e.message }
+            let message = "can't open '%(filename)s': %(error)s"
+            throw new ArgumentTypeError(sub(message, args))
+        }
+
+        let options = Object.assign({ fd, flags: this._flags }, this._options)
+        if (this._flags.includes('r')) {
+            return fs.createReadStream(undefined, options)
+        } else if (this._flags.includes('w')) {
+            return fs.createWriteStream(undefined, options)
+        } else {
+            let msg = sub('argument "%s" with mode %r', string, this._flags)
+            throw new TypeError(msg)
+        }
+    }
+
+    [util.inspect.custom]() {
+        let args = [ this._flags ]
+        let kwargs = Object.entries(this._options).map(([ k, v ]) => {
+            if (k === 'mode') v = { value: v, [util.inspect.custom]() { return '0o' + this.value.toString(8) } }
+            return [ k, v ]
+        })
+        let args_str = []
+                .concat(args.filter(arg => arg !== -1).map(repr))
+                .concat(kwargs.filter(([/*kw*/, arg]) => arg !== undefined)
+                    .map(([kw, arg]) => sub('%s=%r', kw, arg)))
+                .join(', ')
+        return sub('%s(%s)', this.constructor.name, args_str)
+    }
+
+    toString() {
+        return this[util.inspect.custom]()
+    }
+})
+
+// ===========================
+// Optional and Positional Parsing
+// ===========================
+const Namespace = _callable(class Namespace extends _AttributeHolder() {
+    /*
+     *  Simple object for storing attributes.
+     *
+     *  Implements equality by attribute names and values, and provides a simple
+     *  string representation.
+     */
+
+    constructor(options = {}) {
+        super()
+        Object.assign(this, options)
+    }
+})
+
+// unset string tag to mimic plain object
+Namespace.prototype[Symbol.toStringTag] = undefined
+
+
+const _ActionsContainer = _camelcase_alias(_callable(class _ActionsContainer {
+
+    constructor() {
+        let [
+            description,
+            prefix_chars,
+            argument_default,
+            conflict_handler
+        ] = _parse_opts(arguments, {
+            description: no_default,
+            prefix_chars: no_default,
+            argument_default: no_default,
+            conflict_handler: no_default
+        })
+
+        this.description = description
+        this.argument_default = argument_default
+        this.prefix_chars = prefix_chars
+        this.conflict_handler = conflict_handler
+
+        // set up registries
+        this._registries = {}
+
+        // register actions
+        this.register('action', undefined, _StoreAction)
+        this.register('action', 'store', _StoreAction)
+        this.register('action', 'store_const', _StoreConstAction)
+        this.register('action', 'store_true', _StoreTrueAction)
+        this.register('action', 'store_false', _StoreFalseAction)
+        this.register('action', 'append', _AppendAction)
+        this.register('action', 'append_const', _AppendConstAction)
+        this.register('action', 'count', _CountAction)
+        this.register('action', 'help', _HelpAction)
+        this.register('action', 'version', _VersionAction)
+        this.register('action', 'parsers', _SubParsersAction)
+        this.register('action', 'extend', _ExtendAction)
+        // LEGACY (v1 compatibility): camelcase variants
+        ;[ 'storeConst', 'storeTrue', 'storeFalse', 'appendConst' ].forEach(old_name => {
+            let new_name = _to_new_name(old_name)
+            this.register('action', old_name, util.deprecate(this._registry_get('action', new_name),
+                sub('{action: "%s"} is renamed to {action: "%s"}', old_name, new_name)))
+        })
+        // end
+
+        // raise an exception if the conflict handler is invalid
+        this._get_handler()
+
+        // action storage
+        this._actions = []
+        this._option_string_actions = {}
+
+        // groups
+        this._action_groups = []
+        this._mutually_exclusive_groups = []
+
+        // defaults storage
+        this._defaults = {}
+
+        // determines whether an "option" looks like a negative number
+        this._negative_number_matcher = /^-\d+$|^-\d*\.\d+$/
+
+        // whether or not there are any optionals that look like negative
+        // numbers -- uses a list so it can be shared and edited
+        this._has_negative_number_optionals = []
+    }
+
+    // ====================
+    // Registration methods
+    // ====================
+    register(registry_name, value, object) {
+        let registry = setdefault(this._registries, registry_name, {})
+        registry[value] = object
+    }
+
+    _registry_get(registry_name, value, default_value = undefined) {
+        return getattr(this._registries[registry_name], value, default_value)
+    }
+
+    // ==================================
+    // Namespace default accessor methods
+    // ==================================
+    set_defaults(kwargs) {
+        Object.assign(this._defaults, kwargs)
+
+        // if these defaults match any existing arguments, replace
+        // the previous default on the object with the new one
+        for (let action of this._actions) {
+            if (action.dest in kwargs) {
+                action.default = kwargs[action.dest]
+            }
+        }
+    }
+
+    get_default(dest) {
+        for (let action of this._actions) {
+            if (action.dest === dest && action.default !== undefined) {
+                return action.default
+            }
+        }
+        return this._defaults[dest]
+    }
+
+
+    // =======================
+    // Adding argument actions
+    // =======================
+    add_argument() {
+        /*
+         *  add_argument(dest, ..., name=value, ...)
+         *  add_argument(option_string, option_string, ..., name=value, ...)
+         */
+        let [
+            args,
+            kwargs
+        ] = _parse_opts(arguments, {
+            '*args': no_default,
+            '**kwargs': no_default
+        })
+        // LEGACY (v1 compatibility), old-style add_argument([ args ], { options })
+        if (args.length === 1 && Array.isArray(args[0])) {
+            args = args[0]
+            deprecate('argument-array',
+                sub('use add_argument(%(args)s, {...}) instead of add_argument([ %(args)s ], { ... })', {
+                    args: args.map(repr).join(', ')
+                }))
+        }
+        // end
+
+        // if no positional args are supplied or only one is supplied and
+        // it doesn't look like an option string, parse a positional
+        // argument
+        let chars = this.prefix_chars
+        if (!args.length || args.length === 1 && !chars.includes(args[0][0])) {
+            if (args.length && 'dest' in kwargs) {
+                throw new TypeError('dest supplied twice for positional argument')
+            }
+            kwargs = this._get_positional_kwargs(...args, kwargs)
+
+        // otherwise, we're adding an optional argument
+        } else {
+            kwargs = this._get_optional_kwargs(...args, kwargs)
+        }
+
+        // if no default was supplied, use the parser-level default
+        if (!('default' in kwargs)) {
+            let dest = kwargs.dest
+            if (dest in this._defaults) {
+                kwargs.default = this._defaults[dest]
+            } else if (this.argument_default !== undefined) {
+                kwargs.default = this.argument_default
+            }
+        }
+
+        // create the action object, and add it to the parser
+        let action_class = this._pop_action_class(kwargs)
+        if (typeof action_class !== 'function') {
+            throw new TypeError(sub('unknown action "%s"', action_class))
+        }
+        // eslint-disable-next-line new-cap
+        let action = new action_class(kwargs)
+
+        // raise an error if the action type is not callable
+        let type_func = this._registry_get('type', action.type, action.type)
+        if (typeof type_func !== 'function') {
+            throw new TypeError(sub('%r is not callable', type_func))
+        }
+
+        if (type_func === FileType) {
+            throw new TypeError(sub('%r is a FileType class object, instance of it' +
+                                    ' must be passed', type_func))
+        }
+
+        // raise an error if the metavar does not match the type
+        if ('_get_formatter' in this) {
+            try {
+                this._get_formatter()._format_args(action, undefined)
+            } catch (err) {
+                // check for 'invalid nargs value' is an artifact of TypeError and ValueError in js being the same
+                if (err instanceof TypeError && err.message !== 'invalid nargs value') {
+                    throw new TypeError('length of metavar tuple does not match nargs')
+                } else {
+                    throw err
+                }
+            }
+        }
+
+        return this._add_action(action)
+    }
+
+    add_argument_group() {
+        let group = _ArgumentGroup(this, ...arguments)
+        this._action_groups.push(group)
+        return group
+    }
+
+    add_mutually_exclusive_group() {
+        // eslint-disable-next-line no-use-before-define
+        let group = _MutuallyExclusiveGroup(this, ...arguments)
+        this._mutually_exclusive_groups.push(group)
+        return group
+    }
+
+    _add_action(action) {
+        // resolve any conflicts
+        this._check_conflict(action)
+
+        // add to actions list
+        this._actions.push(action)
+        action.container = this
+
+        // index the action by any option strings it has
+        for (let option_string of action.option_strings) {
+            this._option_string_actions[option_string] = action
+        }
+
+        // set the flag if any option strings look like negative numbers
+        for (let option_string of action.option_strings) {
+            if (this._negative_number_matcher.test(option_string)) {
+                if (!this._has_negative_number_optionals.length) {
+                    this._has_negative_number_optionals.push(true)
+                }
+            }
+        }
+
+        // return the created action
+        return action
+    }
+
+    _remove_action(action) {
+        _array_remove(this._actions, action)
+    }
+
+    _add_container_actions(container) {
+        // collect groups by titles
+        let title_group_map = {}
+        for (let group of this._action_groups) {
+            if (group.title in title_group_map) {
+                let msg = 'cannot merge actions - two groups are named %r'
+                throw new TypeError(sub(msg, group.title))
+            }
+            title_group_map[group.title] = group
+        }
+
+        // map each action to its group
+        let group_map = new Map()
+        for (let group of container._action_groups) {
+
+            // if a group with the title exists, use that, otherwise
+            // create a new group matching the container's group
+            if (!(group.title in title_group_map)) {
+                title_group_map[group.title] = this.add_argument_group({
+                    title: group.title,
+                    description: group.description,
+                    conflict_handler: group.conflict_handler
+                })
+            }
+
+            // map the actions to their new group
+            for (let action of group._group_actions) {
+                group_map.set(action, title_group_map[group.title])
+            }
+        }
+
+        // add container's mutually exclusive groups
+        // NOTE: if add_mutually_exclusive_group ever gains title= and
+        // description= then this code will need to be expanded as above
+        for (let group of container._mutually_exclusive_groups) {
+            let mutex_group = this.add_mutually_exclusive_group({
+                required: group.required
+            })
+
+            // map the actions to their new mutex group
+            for (let action of group._group_actions) {
+                group_map.set(action, mutex_group)
+            }
+        }
+
+        // add all actions to this container or their group
+        for (let action of container._actions) {
+            group_map.get(action)._add_action(action)
+        }
+    }
+
+    _get_positional_kwargs() {
+        let [
+            dest,
+            kwargs
+        ] = _parse_opts(arguments, {
+            dest: no_default,
+            '**kwargs': no_default
+        })
+
+        // make sure required is not specified
+        if ('required' in kwargs) {
+            let msg = "'required' is an invalid argument for positionals"
+            throw new TypeError(msg)
+        }
+
+        // mark positional arguments as required if at least one is
+        // always required
+        if (![OPTIONAL, ZERO_OR_MORE].includes(kwargs.nargs)) {
+            kwargs.required = true
+        }
+        if (kwargs.nargs === ZERO_OR_MORE && !('default' in kwargs)) {
+            kwargs.required = true
+        }
+
+        // return the keyword arguments with no option strings
+        return Object.assign(kwargs, { dest, option_strings: [] })
+    }
+
+    _get_optional_kwargs() {
+        let [
+            args,
+            kwargs
+        ] = _parse_opts(arguments, {
+            '*args': no_default,
+            '**kwargs': no_default
+        })
+
+        // determine short and long option strings
+        let option_strings = []
+        let long_option_strings = []
+        let option_string
+        for (option_string of args) {
+            // error on strings that don't start with an appropriate prefix
+            if (!this.prefix_chars.includes(option_string[0])) {
+                let args = {option: option_string,
+                            prefix_chars: this.prefix_chars}
+                let msg = 'invalid option string %(option)r: ' +
+                          'must start with a character %(prefix_chars)r'
+                throw new TypeError(sub(msg, args))
+            }
+
+            // strings starting with two prefix characters are long options
+            option_strings.push(option_string)
+            if (option_string.length > 1 && this.prefix_chars.includes(option_string[1])) {
+                long_option_strings.push(option_string)
+            }
+        }
+
+        // infer destination, '--foo-bar' -> 'foo_bar' and '-x' -> 'x'
+        let dest = kwargs.dest
+        delete kwargs.dest
+        if (dest === undefined) {
+            let dest_option_string
+            if (long_option_strings.length) {
+                dest_option_string = long_option_strings[0]
+            } else {
+                dest_option_string = option_strings[0]
+            }
+            dest = _string_lstrip(dest_option_string, this.prefix_chars)
+            if (!dest) {
+                let msg = 'dest= is required for options like %r'
+                throw new TypeError(sub(msg, option_string))
+            }
+            dest = dest.replace(/-/g, '_')
+        }
+
+        // return the updated keyword arguments
+        return Object.assign(kwargs, { dest, option_strings })
+    }
+
+    _pop_action_class(kwargs, default_value = undefined) {
+        let action = getattr(kwargs, 'action', default_value)
+        delete kwargs.action
+        return this._registry_get('action', action, action)
+    }
+
+    _get_handler() {
+        // determine function from conflict handler string
+        let handler_func_name = sub('_handle_conflict_%s', this.conflict_handler)
+        if (typeof this[handler_func_name] === 'function') {
+            return this[handler_func_name]
+        } else {
+            let msg = 'invalid conflict_resolution value: %r'
+            throw new TypeError(sub(msg, this.conflict_handler))
+        }
+    }
+
+    _check_conflict(action) {
+
+        // find all options that conflict with this option
+        let confl_optionals = []
+        for (let option_string of action.option_strings) {
+            if (hasattr(this._option_string_actions, option_string)) {
+                let confl_optional = this._option_string_actions[option_string]
+                confl_optionals.push([ option_string, confl_optional ])
+            }
+        }
+
+        // resolve any conflicts
+        if (confl_optionals.length) {
+            let conflict_handler = this._get_handler()
+            conflict_handler.call(this, action, confl_optionals)
+        }
+    }
+
+    _handle_conflict_error(action, conflicting_actions) {
+        let message = conflicting_actions.length === 1 ?
+            'conflicting option string: %s' :
+            'conflicting option strings: %s'
+        let conflict_string = conflicting_actions.map(([ option_string/*, action*/ ]) => option_string).join(', ')
+        throw new ArgumentError(action, sub(message, conflict_string))
+    }
+
+    _handle_conflict_resolve(action, conflicting_actions) {
+
+        // remove all conflicting options
+        for (let [ option_string, action ] of conflicting_actions) {
+
+            // remove the conflicting option
+            _array_remove(action.option_strings, option_string)
+            delete this._option_string_actions[option_string]
+
+            // if the option now has no option string, remove it from the
+            // container holding it
+            if (!action.option_strings.length) {
+                action.container._remove_action(action)
+            }
+        }
+    }
+}))
+
+
+const _ArgumentGroup = _callable(class _ArgumentGroup extends _ActionsContainer {
+
+    constructor() {
+        let [
+            container,
+            title,
+            description,
+            kwargs
+        ] = _parse_opts(arguments, {
+            container: no_default,
+            title: undefined,
+            description: undefined,
+            '**kwargs': no_default
+        })
+
+        // add any missing keyword arguments by checking the container
+        setdefault(kwargs, 'conflict_handler', container.conflict_handler)
+        setdefault(kwargs, 'prefix_chars', container.prefix_chars)
+        setdefault(kwargs, 'argument_default', container.argument_default)
+        super(Object.assign({ description }, kwargs))
+
+        // group attributes
+        this.title = title
+        this._group_actions = []
+
+        // share most attributes with the container
+        this._registries = container._registries
+        this._actions = container._actions
+        this._option_string_actions = container._option_string_actions
+        this._defaults = container._defaults
+        this._has_negative_number_optionals =
+            container._has_negative_number_optionals
+        this._mutually_exclusive_groups = container._mutually_exclusive_groups
+    }
+
+    _add_action(action) {
+        action = super._add_action(action)
+        this._group_actions.push(action)
+        return action
+    }
+
+    _remove_action(action) {
+        super._remove_action(action)
+        _array_remove(this._group_actions, action)
+    }
+})
+
+
+const _MutuallyExclusiveGroup = _callable(class _MutuallyExclusiveGroup extends _ArgumentGroup {
+
+    constructor() {
+        let [
+            container,
+            required
+        ] = _parse_opts(arguments, {
+            container: no_default,
+            required: false
+        })
+
+        super(container)
+        this.required = required
+        this._container = container
+    }
+
+    _add_action(action) {
+        if (action.required) {
+            let msg = 'mutually exclusive arguments must be optional'
+            throw new TypeError(msg)
+        }
+        action = this._container._add_action(action)
+        this._group_actions.push(action)
+        return action
+    }
+
+    _remove_action(action) {
+        this._container._remove_action(action)
+        _array_remove(this._group_actions, action)
+    }
+})
+
+
+const ArgumentParser = _camelcase_alias(_callable(class ArgumentParser extends _AttributeHolder(_ActionsContainer) {
+    /*
+     *  Object for parsing command line strings into Python objects.
+     *
+     *  Keyword Arguments:
+     *      - prog -- The name of the program (default: sys.argv[0])
+     *      - usage -- A usage message (default: auto-generated from arguments)
+     *      - description -- A description of what the program does
+     *      - epilog -- Text following the argument descriptions
+     *      - parents -- Parsers whose arguments should be copied into this one
+     *      - formatter_class -- HelpFormatter class for printing help messages
+     *      - prefix_chars -- Characters that prefix optional arguments
+     *      - fromfile_prefix_chars -- Characters that prefix files containing
+     *          additional arguments
+     *      - argument_default -- The default value for all arguments
+     *      - conflict_handler -- String indicating how to handle conflicts
+     *      - add_help -- Add a -h/-help option
+     *      - allow_abbrev -- Allow long options to be abbreviated unambiguously
+     *      - exit_on_error -- Determines whether or not ArgumentParser exits with
+     *          error info when an error occurs
+     */
+
+    constructor() {
+        let [
+            prog,
+            usage,
+            description,
+            epilog,
+            parents,
+            formatter_class,
+            prefix_chars,
+            fromfile_prefix_chars,
+            argument_default,
+            conflict_handler,
+            add_help,
+            allow_abbrev,
+            exit_on_error,
+            debug, // LEGACY (v1 compatibility), debug mode
+            version // LEGACY (v1 compatibility), version
+        ] = _parse_opts(arguments, {
+            prog: undefined,
+            usage: undefined,
+            description: undefined,
+            epilog: undefined,
+            parents: [],
+            formatter_class: HelpFormatter,
+            prefix_chars: '-',
+            fromfile_prefix_chars: undefined,
+            argument_default: undefined,
+            conflict_handler: 'error',
+            add_help: true,
+            allow_abbrev: true,
+            exit_on_error: true,
+            debug: undefined, // LEGACY (v1 compatibility), debug mode
+            version: undefined // LEGACY (v1 compatibility), version
+        })
+
+        // LEGACY (v1 compatibility)
+        if (debug !== undefined) {
+            deprecate('debug',
+                'The "debug" argument to ArgumentParser is deprecated. Please ' +
+                'override ArgumentParser.exit function instead.'
+            )
+        }
+
+        if (version !== undefined) {
+            deprecate('version',
+                'The "version" argument to ArgumentParser is deprecated. Please use ' +
+                "add_argument(..., { action: 'version', version: 'N', ... }) instead."
+            )
+        }
+        // end
+
+        super({
+            description,
+            prefix_chars,
+            argument_default,
+            conflict_handler
+        })
+
+        // default setting for prog
+        if (prog === undefined) {
+            prog = path.basename(get_argv()[0] || '')
+        }
+
+        this.prog = prog
+        this.usage = usage
+        this.epilog = epilog
+        this.formatter_class = formatter_class
+        this.fromfile_prefix_chars = fromfile_prefix_chars
+        this.add_help = add_help
+        this.allow_abbrev = allow_abbrev
+        this.exit_on_error = exit_on_error
+        // LEGACY (v1 compatibility), debug mode
+        this.debug = debug
+        // end
+
+        this._positionals = this.add_argument_group('positional arguments')
+        this._optionals = this.add_argument_group('optional arguments')
+        this._subparsers = undefined
+
+        // register types
+        function identity(string) {
+            return string
+        }
+        this.register('type', undefined, identity)
+        this.register('type', null, identity)
+        this.register('type', 'auto', identity)
+        this.register('type', 'int', function (x) {
+            let result = Number(x)
+            if (!Number.isInteger(result)) {
+                throw new TypeError(sub('could not convert string to int: %r', x))
+            }
+            return result
+        })
+        this.register('type', 'float', function (x) {
+            let result = Number(x)
+            if (isNaN(result)) {
+                throw new TypeError(sub('could not convert string to float: %r', x))
+            }
+            return result
+        })
+        this.register('type', 'str', String)
+        // LEGACY (v1 compatibility): custom types
+        this.register('type', 'string',
+            util.deprecate(String, 'use {type:"str"} or {type:String} instead of {type:"string"}'))
+        // end
+
+        // add help argument if necessary
+        // (using explicit default to override global argument_default)
+        let default_prefix = prefix_chars.includes('-') ? '-' : prefix_chars[0]
+        if (this.add_help) {
+            this.add_argument(
+                default_prefix + 'h',
+                default_prefix.repeat(2) + 'help',
+                {
+                    action: 'help',
+                    default: SUPPRESS,
+                    help: 'show this help message and exit'
+                }
+            )
+        }
+        // LEGACY (v1 compatibility), version
+        if (version) {
+            this.add_argument(
+                default_prefix + 'v',
+                default_prefix.repeat(2) + 'version',
+                {
+                    action: 'version',
+                    default: SUPPRESS,
+                    version: this.version,
+                    help: "show program's version number and exit"
+                }
+            )
+        }
+        // end
+
+        // add parent arguments and defaults
+        for (let parent of parents) {
+            this._add_container_actions(parent)
+            Object.assign(this._defaults, parent._defaults)
+        }
+    }
+
+    // =======================
+    // Pretty __repr__ methods
+    // =======================
+    _get_kwargs() {
+        let names = [
+            'prog',
+            'usage',
+            'description',
+            'formatter_class',
+            'conflict_handler',
+            'add_help'
+        ]
+        return names.map(name => [ name, getattr(this, name) ])
+    }
+
+    // ==================================
+    // Optional/Positional adding methods
+    // ==================================
+    add_subparsers() {
+        let [
+            kwargs
+        ] = _parse_opts(arguments, {
+            '**kwargs': no_default
+        })
+
+        if (this._subparsers !== undefined) {
+            this.error('cannot have multiple subparser arguments')
+        }
+
+        // add the parser class to the arguments if it's not present
+        setdefault(kwargs, 'parser_class', this.constructor)
+
+        if ('title' in kwargs || 'description' in kwargs) {
+            let title = getattr(kwargs, 'title', 'subcommands')
+            let description = getattr(kwargs, 'description', undefined)
+            delete kwargs.title
+            delete kwargs.description
+            this._subparsers = this.add_argument_group(title, description)
+        } else {
+            this._subparsers = this._positionals
+        }
+
+        // prog defaults to the usage message of this parser, skipping
+        // optional arguments and with no "usage:" prefix
+        if (kwargs.prog === undefined) {
+            let formatter = this._get_formatter()
+            let positionals = this._get_positional_actions()
+            let groups = this._mutually_exclusive_groups
+            formatter.add_usage(this.usage, positionals, groups, '')
+            kwargs.prog = formatter.format_help().trim()
+        }
+
+        // create the parsers action and add it to the positionals list
+        let parsers_class = this._pop_action_class(kwargs, 'parsers')
+        // eslint-disable-next-line new-cap
+        let action = new parsers_class(Object.assign({ option_strings: [] }, kwargs))
+        this._subparsers._add_action(action)
+
+        // return the created parsers action
+        return action
+    }
+
+    _add_action(action) {
+        if (action.option_strings.length) {
+            this._optionals._add_action(action)
+        } else {
+            this._positionals._add_action(action)
+        }
+        return action
+    }
+
+    _get_optional_actions() {
+        return this._actions.filter(action => action.option_strings.length)
+    }
+
+    _get_positional_actions() {
+        return this._actions.filter(action => !action.option_strings.length)
+    }
+
+    // =====================================
+    // Command line argument parsing methods
+    // =====================================
+    parse_args(args = undefined, namespace = undefined) {
+        let argv
+        [ args, argv ] = this.parse_known_args(args, namespace)
+        if (argv && argv.length > 0) {
+            let msg = 'unrecognized arguments: %s'
+            this.error(sub(msg, argv.join(' ')))
+        }
+        return args
+    }
+
+    parse_known_args(args = undefined, namespace = undefined) {
+        if (args === undefined) {
+            args = get_argv().slice(1)
+        }
+
+        // default Namespace built from parser defaults
+        if (namespace === undefined) {
+            namespace = new Namespace()
+        }
+
+        // add any action defaults that aren't present
+        for (let action of this._actions) {
+            if (action.dest !== SUPPRESS) {
+                if (!hasattr(namespace, action.dest)) {
+                    if (action.default !== SUPPRESS) {
+                        setattr(namespace, action.dest, action.default)
+                    }
+                }
+            }
+        }
+
+        // add any parser defaults that aren't present
+        for (let dest of Object.keys(this._defaults)) {
+            if (!hasattr(namespace, dest)) {
+                setattr(namespace, dest, this._defaults[dest])
+            }
+        }
+
+        // parse the arguments and exit if there are any errors
+        if (this.exit_on_error) {
+            try {
+                [ namespace, args ] = this._parse_known_args(args, namespace)
+            } catch (err) {
+                if (err instanceof ArgumentError) {
+                    this.error(err.message)
+                } else {
+                    throw err
+                }
+            }
+        } else {
+            [ namespace, args ] = this._parse_known_args(args, namespace)
+        }
+
+        if (hasattr(namespace, _UNRECOGNIZED_ARGS_ATTR)) {
+            args = args.concat(getattr(namespace, _UNRECOGNIZED_ARGS_ATTR))
+            delattr(namespace, _UNRECOGNIZED_ARGS_ATTR)
+        }
+
+        return [ namespace, args ]
+    }
+
+    _parse_known_args(arg_strings, namespace) {
+        // replace arg strings that are file references
+        if (this.fromfile_prefix_chars !== undefined) {
+            arg_strings = this._read_args_from_files(arg_strings)
+        }
+
+        // map all mutually exclusive arguments to the other arguments
+        // they can't occur with
+        let action_conflicts = new Map()
+        for (let mutex_group of this._mutually_exclusive_groups) {
+            let group_actions = mutex_group._group_actions
+            for (let [ i, mutex_action ] of Object.entries(mutex_group._group_actions)) {
+                let conflicts = action_conflicts.get(mutex_action) || []
+                conflicts = conflicts.concat(group_actions.slice(0, +i))
+                conflicts = conflicts.concat(group_actions.slice(+i + 1))
+                action_conflicts.set(mutex_action, conflicts)
+            }
+        }
+
+        // find all option indices, and determine the arg_string_pattern
+        // which has an 'O' if there is an option at an index,
+        // an 'A' if there is an argument, or a '-' if there is a '--'
+        let option_string_indices = {}
+        let arg_string_pattern_parts = []
+        let arg_strings_iter = Object.entries(arg_strings)[Symbol.iterator]()
+        for (let [ i, arg_string ] of arg_strings_iter) {
+
+            // all args after -- are non-options
+            if (arg_string === '--') {
+                arg_string_pattern_parts.push('-')
+                for ([ i, arg_string ] of arg_strings_iter) {
+                    arg_string_pattern_parts.push('A')
+                }
+
+            // otherwise, add the arg to the arg strings
+            // and note the index if it was an option
+            } else {
+                let option_tuple = this._parse_optional(arg_string)
+                let pattern
+                if (option_tuple === undefined) {
+                    pattern = 'A'
+                } else {
+                    option_string_indices[i] = option_tuple
+                    pattern = 'O'
+                }
+                arg_string_pattern_parts.push(pattern)
+            }
+        }
+
+        // join the pieces together to form the pattern
+        let arg_strings_pattern = arg_string_pattern_parts.join('')
+
+        // converts arg strings to the appropriate and then takes the action
+        let seen_actions = new Set()
+        let seen_non_default_actions = new Set()
+        let extras
+
+        let take_action = (action, argument_strings, option_string = undefined) => {
+            seen_actions.add(action)
+            let argument_values = this._get_values(action, argument_strings)
+
+            // error if this argument is not allowed with other previously
+            // seen arguments, assuming that actions that use the default
+            // value don't really count as "present"
+            if (argument_values !== action.default) {
+                seen_non_default_actions.add(action)
+                for (let conflict_action of action_conflicts.get(action) || []) {
+                    if (seen_non_default_actions.has(conflict_action)) {
+                        let msg = 'not allowed with argument %s'
+                        let action_name = _get_action_name(conflict_action)
+                        throw new ArgumentError(action, sub(msg, action_name))
+                    }
+                }
+            }
+
+            // take the action if we didn't receive a SUPPRESS value
+            // (e.g. from a default)
+            if (argument_values !== SUPPRESS) {
+                action(this, namespace, argument_values, option_string)
+            }
+        }
+
+        // function to convert arg_strings into an optional action
+        let consume_optional = start_index => {
+
+            // get the optional identified at this index
+            let option_tuple = option_string_indices[start_index]
+            let [ action, option_string, explicit_arg ] = option_tuple
+
+            // identify additional optionals in the same arg string
+            // (e.g. -xyz is the same as -x -y -z if no args are required)
+            let action_tuples = []
+            let stop
+            for (;;) {
+
+                // if we found no optional action, skip it
+                if (action === undefined) {
+                    extras.push(arg_strings[start_index])
+                    return start_index + 1
+                }
+
+                // if there is an explicit argument, try to match the
+                // optional's string arguments to only this
+                if (explicit_arg !== undefined) {
+                    let arg_count = this._match_argument(action, 'A')
+
+                    // if the action is a single-dash option and takes no
+                    // arguments, try to parse more single-dash options out
+                    // of the tail of the option string
+                    let chars = this.prefix_chars
+                    if (arg_count === 0 && !chars.includes(option_string[1])) {
+                        action_tuples.push([ action, [], option_string ])
+                        let char = option_string[0]
+                        option_string = char + explicit_arg[0]
+                        let new_explicit_arg = explicit_arg.slice(1) || undefined
+                        let optionals_map = this._option_string_actions
+                        if (hasattr(optionals_map, option_string)) {
+                            action = optionals_map[option_string]
+                            explicit_arg = new_explicit_arg
+                        } else {
+                            let msg = 'ignored explicit argument %r'
+                            throw new ArgumentError(action, sub(msg, explicit_arg))
+                        }
+
+                    // if the action expect exactly one argument, we've
+                    // successfully matched the option; exit the loop
+                    } else if (arg_count === 1) {
+                        stop = start_index + 1
+                        let args = [ explicit_arg ]
+                        action_tuples.push([ action, args, option_string ])
+                        break
+
+                    // error if a double-dash option did not use the
+                    // explicit argument
+                    } else {
+                        let msg = 'ignored explicit argument %r'
+                        throw new ArgumentError(action, sub(msg, explicit_arg))
+                    }
+
+                // if there is no explicit argument, try to match the
+                // optional's string arguments with the following strings
+                // if successful, exit the loop
+                } else {
+                    let start = start_index + 1
+                    let selected_patterns = arg_strings_pattern.slice(start)
+                    let arg_count = this._match_argument(action, selected_patterns)
+                    stop = start + arg_count
+                    let args = arg_strings.slice(start, stop)
+                    action_tuples.push([ action, args, option_string ])
+                    break
+                }
+            }
+
+            // add the Optional to the list and return the index at which
+            // the Optional's string args stopped
+            assert(action_tuples.length)
+            for (let [ action, args, option_string ] of action_tuples) {
+                take_action(action, args, option_string)
+            }
+            return stop
+        }
+
+        // the list of Positionals left to be parsed; this is modified
+        // by consume_positionals()
+        let positionals = this._get_positional_actions()
+
+        // function to convert arg_strings into positional actions
+        let consume_positionals = start_index => {
+            // match as many Positionals as possible
+            let selected_pattern = arg_strings_pattern.slice(start_index)
+            let arg_counts = this._match_arguments_partial(positionals, selected_pattern)
+
+            // slice off the appropriate arg strings for each Positional
+            // and add the Positional and its args to the list
+            for (let i = 0; i < positionals.length && i < arg_counts.length; i++) {
+                let action = positionals[i]
+                let arg_count = arg_counts[i]
+                let args = arg_strings.slice(start_index, start_index + arg_count)
+                start_index += arg_count
+                take_action(action, args)
+            }
+
+            // slice off the Positionals that we just parsed and return the
+            // index at which the Positionals' string args stopped
+            positionals = positionals.slice(arg_counts.length)
+            return start_index
+        }
+
+        // consume Positionals and Optionals alternately, until we have
+        // passed the last option string
+        extras = []
+        let start_index = 0
+        let max_option_string_index = Math.max(-1, ...Object.keys(option_string_indices).map(Number))
+        while (start_index <= max_option_string_index) {
+
+            // consume any Positionals preceding the next option
+            let next_option_string_index = Math.min(
+                // eslint-disable-next-line no-loop-func
+                ...Object.keys(option_string_indices).map(Number).filter(index => index >= start_index)
+            )
+            if (start_index !== next_option_string_index) {
+                let positionals_end_index = consume_positionals(start_index)
+
+                // only try to parse the next optional if we didn't consume
+                // the option string during the positionals parsing
+                if (positionals_end_index > start_index) {
+                    start_index = positionals_end_index
+                    continue
+                } else {
+                    start_index = positionals_end_index
+                }
+            }
+
+            // if we consumed all the positionals we could and we're not
+            // at the index of an option string, there were extra arguments
+            if (!(start_index in option_string_indices)) {
+                let strings = arg_strings.slice(start_index, next_option_string_index)
+                extras = extras.concat(strings)
+                start_index = next_option_string_index
+            }
+
+            // consume the next optional and any arguments for it
+            start_index = consume_optional(start_index)
+        }
+
+        // consume any positionals following the last Optional
+        let stop_index = consume_positionals(start_index)
+
+        // if we didn't consume all the argument strings, there were extras
+        extras = extras.concat(arg_strings.slice(stop_index))
+
+        // make sure all required actions were present and also convert
+        // action defaults which were not given as arguments
+        let required_actions = []
+        for (let action of this._actions) {
+            if (!seen_actions.has(action)) {
+                if (action.required) {
+                    required_actions.push(_get_action_name(action))
+                } else {
+                    // Convert action default now instead of doing it before
+                    // parsing arguments to avoid calling convert functions
+                    // twice (which may fail) if the argument was given, but
+                    // only if it was defined already in the namespace
+                    if (action.default !== undefined &&
+                        typeof action.default === 'string' &&
+                        hasattr(namespace, action.dest) &&
+                        action.default === getattr(namespace, action.dest)) {
+                        setattr(namespace, action.dest,
+                                this._get_value(action, action.default))
+                    }
+                }
+            }
+        }
+
+        if (required_actions.length) {
+            this.error(sub('the following arguments are required: %s',
+                       required_actions.join(', ')))
+        }
+
+        // make sure all required groups had one option present
+        for (let group of this._mutually_exclusive_groups) {
+            if (group.required) {
+                let no_actions_used = true
+                for (let action of group._group_actions) {
+                    if (seen_non_default_actions.has(action)) {
+                        no_actions_used = false
+                        break
+                    }
+                }
+
+                // if no actions were used, report the error
+                if (no_actions_used) {
+                    let names = group._group_actions
+                        .filter(action => action.help !== SUPPRESS)
+                        .map(action => _get_action_name(action))
+                    let msg = 'one of the arguments %s is required'
+                    this.error(sub(msg, names.join(' ')))
+                }
+            }
+        }
+
+        // return the updated namespace and the extra arguments
+        return [ namespace, extras ]
+    }
+
+    _read_args_from_files(arg_strings) {
+        // expand arguments referencing files
+        let new_arg_strings = []
+        for (let arg_string of arg_strings) {
+
+            // for regular arguments, just add them back into the list
+            if (!arg_string || !this.fromfile_prefix_chars.includes(arg_string[0])) {
+                new_arg_strings.push(arg_string)
+
+            // replace arguments referencing files with the file content
+            } else {
+                try {
+                    let args_file = fs.readFileSync(arg_string.slice(1), 'utf8')
+                    let arg_strings = []
+                    for (let arg_line of splitlines(args_file)) {
+                        for (let arg of this.convert_arg_line_to_args(arg_line)) {
+                            arg_strings.push(arg)
+                        }
+                    }
+                    arg_strings = this._read_args_from_files(arg_strings)
+                    new_arg_strings = new_arg_strings.concat(arg_strings)
+                } catch (err) {
+                    this.error(err.message)
+                }
+            }
+        }
+
+        // return the modified argument list
+        return new_arg_strings
+    }
+
+    convert_arg_line_to_args(arg_line) {
+        return [arg_line]
+    }
+
+    _match_argument(action, arg_strings_pattern) {
+        // match the pattern for this action to the arg strings
+        let nargs_pattern = this._get_nargs_pattern(action)
+        let match = arg_strings_pattern.match(new RegExp('^' + nargs_pattern))
+
+        // raise an exception if we weren't able to find a match
+        if (match === null) {
+            let nargs_errors = {
+                undefined: 'expected one argument',
+                [OPTIONAL]: 'expected at most one argument',
+                [ONE_OR_MORE]: 'expected at least one argument'
+            }
+            let msg = nargs_errors[action.nargs]
+            if (msg === undefined) {
+                msg = sub(action.nargs === 1 ? 'expected %s argument' : 'expected %s arguments', action.nargs)
+            }
+            throw new ArgumentError(action, msg)
+        }
+
+        // return the number of arguments matched
+        return match[1].length
+    }
+
+    _match_arguments_partial(actions, arg_strings_pattern) {
+        // progressively shorten the actions list by slicing off the
+        // final actions until we find a match
+        let result = []
+        for (let i of range(actions.length, 0, -1)) {
+            let actions_slice = actions.slice(0, i)
+            let pattern = actions_slice.map(action => this._get_nargs_pattern(action)).join('')
+            let match = arg_strings_pattern.match(new RegExp('^' + pattern))
+            if (match !== null) {
+                result = result.concat(match.slice(1).map(string => string.length))
+                break
+            }
+        }
+
+        // return the list of arg string counts
+        return result
+    }
+
+    _parse_optional(arg_string) {
+        // if it's an empty string, it was meant to be a positional
+        if (!arg_string) {
+            return undefined
+        }
+
+        // if it doesn't start with a prefix, it was meant to be positional
+        if (!this.prefix_chars.includes(arg_string[0])) {
+            return undefined
+        }
+
+        // if the option string is present in the parser, return the action
+        if (arg_string in this._option_string_actions) {
+            let action = this._option_string_actions[arg_string]
+            return [ action, arg_string, undefined ]
+        }
+
+        // if it's just a single character, it was meant to be positional
+        if (arg_string.length === 1) {
+            return undefined
+        }
+
+        // if the option string before the "=" is present, return the action
+        if (arg_string.includes('=')) {
+            let [ option_string, explicit_arg ] = _string_split(arg_string, '=', 1)
+            if (option_string in this._option_string_actions) {
+                let action = this._option_string_actions[option_string]
+                return [ action, option_string, explicit_arg ]
+            }
+        }
+
+        // search through all possible prefixes of the option string
+        // and all actions in the parser for possible interpretations
+        let option_tuples = this._get_option_tuples(arg_string)
+
+        // if multiple actions match, the option string was ambiguous
+        if (option_tuples.length > 1) {
+            let options = option_tuples.map(([ /*action*/, option_string/*, explicit_arg*/ ]) => option_string).join(', ')
+            let args = {option: arg_string, matches: options}
+            let msg = 'ambiguous option: %(option)s could match %(matches)s'
+            this.error(sub(msg, args))
+
+        // if exactly one action matched, this segmentation is good,
+        // so return the parsed action
+        } else if (option_tuples.length === 1) {
+            let [ option_tuple ] = option_tuples
+            return option_tuple
+        }
+
+        // if it was not found as an option, but it looks like a negative
+        // number, it was meant to be positional
+        // unless there are negative-number-like options
+        if (this._negative_number_matcher.test(arg_string)) {
+            if (!this._has_negative_number_optionals.length) {
+                return undefined
+            }
+        }
+
+        // if it contains a space, it was meant to be a positional
+        if (arg_string.includes(' ')) {
+            return undefined
+        }
+
+        // it was meant to be an optional but there is no such option
+        // in this parser (though it might be a valid option in a subparser)
+        return [ undefined, arg_string, undefined ]
+    }
+
+    _get_option_tuples(option_string) {
+        let result = []
+
+        // option strings starting with two prefix characters are only
+        // split at the '='
+        let chars = this.prefix_chars
+        if (chars.includes(option_string[0]) && chars.includes(option_string[1])) {
+            if (this.allow_abbrev) {
+                let option_prefix, explicit_arg
+                if (option_string.includes('=')) {
+                    [ option_prefix, explicit_arg ] = _string_split(option_string, '=', 1)
+                } else {
+                    option_prefix = option_string
+                    explicit_arg = undefined
+                }
+                for (let option_string of Object.keys(this._option_string_actions)) {
+                    if (option_string.startsWith(option_prefix)) {
+                        let action = this._option_string_actions[option_string]
+                        let tup = [ action, option_string, explicit_arg ]
+                        result.push(tup)
+                    }
+                }
+            }
+
+        // single character options can be concatenated with their arguments
+        // but multiple character options always have to have their argument
+        // separate
+        } else if (chars.includes(option_string[0]) && !chars.includes(option_string[1])) {
+            let option_prefix = option_string
+            let explicit_arg = undefined
+            let short_option_prefix = option_string.slice(0, 2)
+            let short_explicit_arg = option_string.slice(2)
+
+            for (let option_string of Object.keys(this._option_string_actions)) {
+                if (option_string === short_option_prefix) {
+                    let action = this._option_string_actions[option_string]
+                    let tup = [ action, option_string, short_explicit_arg ]
+                    result.push(tup)
+                } else if (option_string.startsWith(option_prefix)) {
+                    let action = this._option_string_actions[option_string]
+                    let tup = [ action, option_string, explicit_arg ]
+                    result.push(tup)
+                }
+            }
+
+        // shouldn't ever get here
+        } else {
+            this.error(sub('unexpected option string: %s', option_string))
+        }
+
+        // return the collected option tuples
+        return result
+    }
+
+    _get_nargs_pattern(action) {
+        // in all examples below, we have to allow for '--' args
+        // which are represented as '-' in the pattern
+        let nargs = action.nargs
+        let nargs_pattern
+
+        // the default (None) is assumed to be a single argument
+        if (nargs === undefined) {
+            nargs_pattern = '(-*A-*)'
+
+        // allow zero or one arguments
+        } else if (nargs === OPTIONAL) {
+            nargs_pattern = '(-*A?-*)'
+
+        // allow zero or more arguments
+        } else if (nargs === ZERO_OR_MORE) {
+            nargs_pattern = '(-*[A-]*)'
+
+        // allow one or more arguments
+        } else if (nargs === ONE_OR_MORE) {
+            nargs_pattern = '(-*A[A-]*)'
+
+        // allow any number of options or arguments
+        } else if (nargs === REMAINDER) {
+            nargs_pattern = '([-AO]*)'
+
+        // allow one argument followed by any number of options or arguments
+        } else if (nargs === PARSER) {
+            nargs_pattern = '(-*A[-AO]*)'
+
+        // suppress action, like nargs=0
+        } else if (nargs === SUPPRESS) {
+            nargs_pattern = '(-*-*)'
+
+        // all others should be integers
+        } else {
+            nargs_pattern = sub('(-*%s-*)', 'A'.repeat(nargs).split('').join('-*'))
+        }
+
+        // if this is an optional action, -- is not allowed
+        if (action.option_strings.length) {
+            nargs_pattern = nargs_pattern.replace(/-\*/g, '')
+            nargs_pattern = nargs_pattern.replace(/-/g, '')
+        }
+
+        // return the pattern
+        return nargs_pattern
+    }
+
+    // ========================
+    // Alt command line argument parsing, allowing free intermix
+    // ========================
+
+    parse_intermixed_args(args = undefined, namespace = undefined) {
+        let argv
+        [ args, argv ] = this.parse_known_intermixed_args(args, namespace)
+        if (argv.length) {
+            let msg = 'unrecognized arguments: %s'
+            this.error(sub(msg, argv.join(' ')))
+        }
+        return args
+    }
+
+    parse_known_intermixed_args(args = undefined, namespace = undefined) {
+        // returns a namespace and list of extras
+        //
+        // positional can be freely intermixed with optionals.  optionals are
+        // first parsed with all positional arguments deactivated.  The 'extras'
+        // are then parsed.  If the parser definition is incompatible with the
+        // intermixed assumptions (e.g. use of REMAINDER, subparsers) a
+        // TypeError is raised.
+        //
+        // positionals are 'deactivated' by setting nargs and default to
+        // SUPPRESS.  This blocks the addition of that positional to the
+        // namespace
+
+        let extras
+        let positionals = this._get_positional_actions()
+        let a = positionals.filter(action => [ PARSER, REMAINDER ].includes(action.nargs))
+        if (a.length) {
+            throw new TypeError(sub('parse_intermixed_args: positional arg' +
+                                    ' with nargs=%s', a[0].nargs))
+        }
+
+        for (let group of this._mutually_exclusive_groups) {
+            for (let action of group._group_actions) {
+                if (positionals.includes(action)) {
+                    throw new TypeError('parse_intermixed_args: positional in' +
+                                        ' mutuallyExclusiveGroup')
+                }
+            }
+        }
+
+        let save_usage
+        try {
+            save_usage = this.usage
+            let remaining_args
+            try {
+                if (this.usage === undefined) {
+                    // capture the full usage for use in error messages
+                    this.usage = this.format_usage().slice(7)
+                }
+                for (let action of positionals) {
+                    // deactivate positionals
+                    action.save_nargs = action.nargs
+                    // action.nargs = 0
+                    action.nargs = SUPPRESS
+                    action.save_default = action.default
+                    action.default = SUPPRESS
+                }
+                [ namespace, remaining_args ] = this.parse_known_args(args,
+                                                                      namespace)
+                for (let action of positionals) {
+                    // remove the empty positional values from namespace
+                    let attr = getattr(namespace, action.dest)
+                    if (Array.isArray(attr) && attr.length === 0) {
+                        // eslint-disable-next-line no-console
+                        console.warn(sub('Do not expect %s in %s', action.dest, namespace))
+                        delattr(namespace, action.dest)
+                    }
+                }
+            } finally {
+                // restore nargs and usage before exiting
+                for (let action of positionals) {
+                    action.nargs = action.save_nargs
+                    action.default = action.save_default
+                }
+            }
+            let optionals = this._get_optional_actions()
+            try {
+                // parse positionals.  optionals aren't normally required, but
+                // they could be, so make sure they aren't.
+                for (let action of optionals) {
+                    action.save_required = action.required
+                    action.required = false
+                }
+                for (let group of this._mutually_exclusive_groups) {
+                    group.save_required = group.required
+                    group.required = false
+                }
+                [ namespace, extras ] = this.parse_known_args(remaining_args,
+                                                              namespace)
+            } finally {
+                // restore parser values before exiting
+                for (let action of optionals) {
+                    action.required = action.save_required
+                }
+                for (let group of this._mutually_exclusive_groups) {
+                    group.required = group.save_required
+                }
+            }
+        } finally {
+            this.usage = save_usage
+        }
+        return [ namespace, extras ]
+    }
+
+    // ========================
+    // Value conversion methods
+    // ========================
+    _get_values(action, arg_strings) {
+        // for everything but PARSER, REMAINDER args, strip out first '--'
+        if (![PARSER, REMAINDER].includes(action.nargs)) {
+            try {
+                _array_remove(arg_strings, '--')
+            } catch (err) {}
+        }
+
+        let value
+        // optional argument produces a default when not present
+        if (!arg_strings.length && action.nargs === OPTIONAL) {
+            if (action.option_strings.length) {
+                value = action.const
+            } else {
+                value = action.default
+            }
+            if (typeof value === 'string') {
+                value = this._get_value(action, value)
+                this._check_value(action, value)
+            }
+
+        // when nargs='*' on a positional, if there were no command-line
+        // args, use the default if it is anything other than None
+        } else if (!arg_strings.length && action.nargs === ZERO_OR_MORE &&
+              !action.option_strings.length) {
+            if (action.default !== undefined) {
+                value = action.default
+            } else {
+                value = arg_strings
+            }
+            this._check_value(action, value)
+
+        // single argument or optional argument produces a single value
+        } else if (arg_strings.length === 1 && [undefined, OPTIONAL].includes(action.nargs)) {
+            let arg_string = arg_strings[0]
+            value = this._get_value(action, arg_string)
+            this._check_value(action, value)
+
+        // REMAINDER arguments convert all values, checking none
+        } else if (action.nargs === REMAINDER) {
+            value = arg_strings.map(v => this._get_value(action, v))
+
+        // PARSER arguments convert all values, but check only the first
+        } else if (action.nargs === PARSER) {
+            value = arg_strings.map(v => this._get_value(action, v))
+            this._check_value(action, value[0])
+
+        // SUPPRESS argument does not put anything in the namespace
+        } else if (action.nargs === SUPPRESS) {
+            value = SUPPRESS
+
+        // all other types of nargs produce a list
+        } else {
+            value = arg_strings.map(v => this._get_value(action, v))
+            for (let v of value) {
+                this._check_value(action, v)
+            }
+        }
+
+        // return the converted value
+        return value
+    }
+
+    _get_value(action, arg_string) {
+        let type_func = this._registry_get('type', action.type, action.type)
+        if (typeof type_func !== 'function') {
+            let msg = '%r is not callable'
+            throw new ArgumentError(action, sub(msg, type_func))
+        }
+
+        // convert the value to the appropriate type
+        let result
+        try {
+            try {
+                result = type_func(arg_string)
+            } catch (err) {
+                // Dear TC39, why would you ever consider making es6 classes not callable?
+                // We had one universal interface, [[Call]], which worked for anything
+                // (with familiar this-instanceof guard for classes). Now we have two.
+                if (err instanceof TypeError &&
+                    /Class constructor .* cannot be invoked without 'new'/.test(err.message)) {
+                    // eslint-disable-next-line new-cap
+                    result = new type_func(arg_string)
+                } else {
+                    throw err
+                }
+            }
+
+        } catch (err) {
+            // ArgumentTypeErrors indicate errors
+            if (err instanceof ArgumentTypeError) {
+                //let name = getattr(action.type, 'name', repr(action.type))
+                let msg = err.message
+                throw new ArgumentError(action, msg)
+
+            // TypeErrors or ValueErrors also indicate errors
+            } else if (err instanceof TypeError) {
+                let name = getattr(action.type, 'name', repr(action.type))
+                let args = {type: name, value: arg_string}
+                let msg = 'invalid %(type)s value: %(value)r'
+                throw new ArgumentError(action, sub(msg, args))
+            } else {
+                throw err
+            }
+        }
+
+        // return the converted value
+        return result
+    }
+
+    _check_value(action, value) {
+        // converted value must be one of the choices (if specified)
+        if (action.choices !== undefined && !_choices_to_array(action.choices).includes(value)) {
+            let args = {value,
+                        choices: _choices_to_array(action.choices).map(repr).join(', ')}
+            let msg = 'invalid choice: %(value)r (choose from %(choices)s)'
+            throw new ArgumentError(action, sub(msg, args))
+        }
+    }
+
+    // =======================
+    // Help-formatting methods
+    // =======================
+    format_usage() {
+        let formatter = this._get_formatter()
+        formatter.add_usage(this.usage, this._actions,
+                            this._mutually_exclusive_groups)
+        return formatter.format_help()
+    }
+
+    format_help() {
+        let formatter = this._get_formatter()
+
+        // usage
+        formatter.add_usage(this.usage, this._actions,
+                            this._mutually_exclusive_groups)
+
+        // description
+        formatter.add_text(this.description)
+
+        // positionals, optionals and user-defined groups
+        for (let action_group of this._action_groups) {
+            formatter.start_section(action_group.title)
+            formatter.add_text(action_group.description)
+            formatter.add_arguments(action_group._group_actions)
+            formatter.end_section()
+        }
+
+        // epilog
+        formatter.add_text(this.epilog)
+
+        // determine help from format above
+        return formatter.format_help()
+    }
+
+    _get_formatter() {
+        // eslint-disable-next-line new-cap
+        return new this.formatter_class({ prog: this.prog })
+    }
+
+    // =====================
+    // Help-printing methods
+    // =====================
+    print_usage(file = undefined) {
+        if (file === undefined) file = process.stdout
+        this._print_message(this.format_usage(), file)
+    }
+
+    print_help(file = undefined) {
+        if (file === undefined) file = process.stdout
+        this._print_message(this.format_help(), file)
+    }
+
+    _print_message(message, file = undefined) {
+        if (message) {
+            if (file === undefined) file = process.stderr
+            file.write(message)
+        }
+    }
+
+    // ===============
+    // Exiting methods
+    // ===============
+    exit(status = 0, message = undefined) {
+        if (message) {
+            this._print_message(message, process.stderr)
+        }
+        process.exit(status)
+    }
+
+    error(message) {
+        /*
+         *  error(message: string)
+         *
+         *  Prints a usage message incorporating the message to stderr and
+         *  exits.
+         *
+         *  If you override this in a subclass, it should not return -- it
+         *  should either exit or raise an exception.
+         */
+
+        // LEGACY (v1 compatibility), debug mode
+        if (this.debug === true) throw new Error(message)
+        // end
+        this.print_usage(process.stderr)
+        let args = {prog: this.prog, message: message}
+        this.exit(2, sub('%(prog)s: error: %(message)s\n', args))
+    }
+}))
+
+
+module.exports = {
+    ArgumentParser,
+    ArgumentError,
+    ArgumentTypeError,
+    BooleanOptionalAction,
+    FileType,
+    HelpFormatter,
+    ArgumentDefaultsHelpFormatter,
+    RawDescriptionHelpFormatter,
+    RawTextHelpFormatter,
+    MetavarTypeHelpFormatter,
+    Namespace,
+    Action,
+    ONE_OR_MORE,
+    OPTIONAL,
+    PARSER,
+    REMAINDER,
+    SUPPRESS,
+    ZERO_OR_MORE
+}
+
+// LEGACY (v1 compatibility), Const alias
+Object.defineProperty(module.exports, 'Const', {
+    get() {
+        let result = {}
+        Object.entries({ ONE_OR_MORE, OPTIONAL, PARSER, REMAINDER, SUPPRESS, ZERO_OR_MORE }).forEach(([ n, v ]) => {
+            Object.defineProperty(result, n, {
+                get() {
+                    deprecate(n, sub('use argparse.%s instead of argparse.Const.%s', n, n))
+                    return v
+                }
+            })
+        })
+        Object.entries({ _UNRECOGNIZED_ARGS_ATTR }).forEach(([ n, v ]) => {
+            Object.defineProperty(result, n, {
+                get() {
+                    deprecate(n, sub('argparse.Const.%s is an internal symbol and will no longer be available', n))
+                    return v
+                }
+            })
+        })
+        return result
+    },
+    enumerable: false
+})
+// end

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/lib/sub.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/lib/sub.js
@@ -1,0 +1,67 @@
+// Limited implementation of python % string operator, supports only %s and %r for now
+// (other formats are not used here, but may appear in custom templates)
+
+'use strict'
+
+const { inspect } = require('util')
+
+
+module.exports = function sub(pattern, ...values) {
+    let regex = /%(?:(%)|(-)?(\*)?(?:\((\w+)\))?([A-Za-z]))/g
+
+    let result = pattern.replace(regex, function (_, is_literal, is_left_align, is_padded, name, format) {
+        if (is_literal) return '%'
+
+        let padded_count = 0
+        if (is_padded) {
+            if (values.length === 0) throw new TypeError('not enough arguments for format string')
+            padded_count = values.shift()
+            if (!Number.isInteger(padded_count)) throw new TypeError('* wants int')
+        }
+
+        let str
+        if (name !== undefined) {
+            let dict = values[0]
+            if (typeof dict !== 'object' || dict === null) throw new TypeError('format requires a mapping')
+            if (!(name in dict)) throw new TypeError(`no such key: '${name}'`)
+            str = dict[name]
+        } else {
+            if (values.length === 0) throw new TypeError('not enough arguments for format string')
+            str = values.shift()
+        }
+
+        switch (format) {
+            case 's':
+                str = String(str)
+                break
+            case 'r':
+                str = inspect(str)
+                break
+            case 'd':
+            case 'i':
+                if (typeof str !== 'number') {
+                    throw new TypeError(`%${format} format: a number is required, not ${typeof str}`)
+                }
+                str = String(str.toFixed(0))
+                break
+            default:
+                throw new TypeError(`unsupported format character '${format}'`)
+        }
+
+        if (padded_count > 0) {
+            return is_left_align ? str.padEnd(padded_count) : str.padStart(padded_count)
+        } else {
+            return str
+        }
+    })
+
+    if (values.length) {
+        if (values.length === 1 && typeof values[0] === 'object' && values[0] !== null) {
+            // mapping
+        } else {
+            throw new TypeError('not all arguments converted during string formatting')
+        }
+    }
+
+    return result
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/lib/textwrap.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/lib/textwrap.js
@@ -1,0 +1,440 @@
+// Partial port of python's argparse module, version 3.9.0 (only wrap and fill functions):
+// https://github.com/python/cpython/blob/v3.9.0b4/Lib/textwrap.py
+
+'use strict'
+
+/*
+ * Text wrapping and filling.
+ */
+
+// Copyright (C) 1999-2001 Gregory P. Ward.
+// Copyright (C) 2002, 2003 Python Software Foundation.
+// Copyright (C) 2020 argparse.js authors
+// Originally written by Greg Ward <gward@python.net>
+
+// Hardcode the recognized whitespace characters to the US-ASCII
+// whitespace characters.  The main reason for doing this is that
+// some Unicode spaces (like \u00a0) are non-breaking whitespaces.
+//
+// This less funky little regex just split on recognized spaces. E.g.
+//   "Hello there -- you goof-ball, use the -b option!"
+// splits into
+//   Hello/ /there/ /--/ /you/ /goof-ball,/ /use/ /the/ /-b/ /option!/
+const wordsep_simple_re = /([\t\n\x0b\x0c\r ]+)/
+
+class TextWrapper {
+    /*
+     *  Object for wrapping/filling text.  The public interface consists of
+     *  the wrap() and fill() methods; the other methods are just there for
+     *  subclasses to override in order to tweak the default behaviour.
+     *  If you want to completely replace the main wrapping algorithm,
+     *  you'll probably have to override _wrap_chunks().
+     *
+     *  Several instance attributes control various aspects of wrapping:
+     *    width (default: 70)
+     *      the maximum width of wrapped lines (unless break_long_words
+     *      is false)
+     *    initial_indent (default: "")
+     *      string that will be prepended to the first line of wrapped
+     *      output.  Counts towards the line's width.
+     *    subsequent_indent (default: "")
+     *      string that will be prepended to all lines save the first
+     *      of wrapped output; also counts towards each line's width.
+     *    expand_tabs (default: true)
+     *      Expand tabs in input text to spaces before further processing.
+     *      Each tab will become 0 .. 'tabsize' spaces, depending on its position
+     *      in its line.  If false, each tab is treated as a single character.
+     *    tabsize (default: 8)
+     *      Expand tabs in input text to 0 .. 'tabsize' spaces, unless
+     *      'expand_tabs' is false.
+     *    replace_whitespace (default: true)
+     *      Replace all whitespace characters in the input text by spaces
+     *      after tab expansion.  Note that if expand_tabs is false and
+     *      replace_whitespace is true, every tab will be converted to a
+     *      single space!
+     *    fix_sentence_endings (default: false)
+     *      Ensure that sentence-ending punctuation is always followed
+     *      by two spaces.  Off by default because the algorithm is
+     *      (unavoidably) imperfect.
+     *    break_long_words (default: true)
+     *      Break words longer than 'width'.  If false, those words will not
+     *      be broken, and some lines might be longer than 'width'.
+     *    break_on_hyphens (default: true)
+     *      Allow breaking hyphenated words. If true, wrapping will occur
+     *      preferably on whitespaces and right after hyphens part of
+     *      compound words.
+     *    drop_whitespace (default: true)
+     *      Drop leading and trailing whitespace from lines.
+     *    max_lines (default: None)
+     *      Truncate wrapped lines.
+     *    placeholder (default: ' [...]')
+     *      Append to the last line of truncated text.
+     */
+
+    constructor(options = {}) {
+        let {
+            width = 70,
+            initial_indent = '',
+            subsequent_indent = '',
+            expand_tabs = true,
+            replace_whitespace = true,
+            fix_sentence_endings = false,
+            break_long_words = true,
+            drop_whitespace = true,
+            break_on_hyphens = true,
+            tabsize = 8,
+            max_lines = undefined,
+            placeholder=' [...]'
+        } = options
+
+        this.width = width
+        this.initial_indent = initial_indent
+        this.subsequent_indent = subsequent_indent
+        this.expand_tabs = expand_tabs
+        this.replace_whitespace = replace_whitespace
+        this.fix_sentence_endings = fix_sentence_endings
+        this.break_long_words = break_long_words
+        this.drop_whitespace = drop_whitespace
+        this.break_on_hyphens = break_on_hyphens
+        this.tabsize = tabsize
+        this.max_lines = max_lines
+        this.placeholder = placeholder
+    }
+
+
+    // -- Private methods -----------------------------------------------
+    // (possibly useful for subclasses to override)
+
+    _munge_whitespace(text) {
+        /*
+         *  _munge_whitespace(text : string) -> string
+         *
+         *  Munge whitespace in text: expand tabs and convert all other
+         *  whitespace characters to spaces.  Eg. " foo\\tbar\\n\\nbaz"
+         *  becomes " foo    bar  baz".
+         */
+        if (this.expand_tabs) {
+            text = text.replace(/\t/g, ' '.repeat(this.tabsize)) // not strictly correct in js
+        }
+        if (this.replace_whitespace) {
+            text = text.replace(/[\t\n\x0b\x0c\r]/g, ' ')
+        }
+        return text
+    }
+
+    _split(text) {
+        /*
+         *  _split(text : string) -> [string]
+         *
+         *  Split the text to wrap into indivisible chunks.  Chunks are
+         *  not quite the same as words; see _wrap_chunks() for full
+         *  details.  As an example, the text
+         *    Look, goof-ball -- use the -b option!
+         *  breaks into the following chunks:
+         *    'Look,', ' ', 'goof-', 'ball', ' ', '--', ' ',
+         *    'use', ' ', 'the', ' ', '-b', ' ', 'option!'
+         *  if break_on_hyphens is True, or in:
+         *    'Look,', ' ', 'goof-ball', ' ', '--', ' ',
+         *    'use', ' ', 'the', ' ', '-b', ' ', option!'
+         *  otherwise.
+         */
+        let chunks = text.split(wordsep_simple_re)
+        chunks = chunks.filter(Boolean)
+        return chunks
+    }
+
+    _handle_long_word(reversed_chunks, cur_line, cur_len, width) {
+        /*
+         *  _handle_long_word(chunks : [string],
+         *                    cur_line : [string],
+         *                    cur_len : int, width : int)
+         *
+         *  Handle a chunk of text (most likely a word, not whitespace) that
+         *  is too long to fit in any line.
+         */
+        // Figure out when indent is larger than the specified width, and make
+        // sure at least one character is stripped off on every pass
+        let space_left
+        if (width < 1) {
+            space_left = 1
+        } else {
+            space_left = width - cur_len
+        }
+
+        // If we're allowed to break long words, then do so: put as much
+        // of the next chunk onto the current line as will fit.
+        if (this.break_long_words) {
+            cur_line.push(reversed_chunks[reversed_chunks.length - 1].slice(0, space_left))
+            reversed_chunks[reversed_chunks.length - 1] = reversed_chunks[reversed_chunks.length - 1].slice(space_left)
+
+        // Otherwise, we have to preserve the long word intact.  Only add
+        // it to the current line if there's nothing already there --
+        // that minimizes how much we violate the width constraint.
+        } else if (!cur_line) {
+            cur_line.push(...reversed_chunks.pop())
+        }
+
+        // If we're not allowed to break long words, and there's already
+        // text on the current line, do nothing.  Next time through the
+        // main loop of _wrap_chunks(), we'll wind up here again, but
+        // cur_len will be zero, so the next line will be entirely
+        // devoted to the long word that we can't handle right now.
+    }
+
+    _wrap_chunks(chunks) {
+        /*
+         *  _wrap_chunks(chunks : [string]) -> [string]
+         *
+         *  Wrap a sequence of text chunks and return a list of lines of
+         *  length 'self.width' or less.  (If 'break_long_words' is false,
+         *  some lines may be longer than this.)  Chunks correspond roughly
+         *  to words and the whitespace between them: each chunk is
+         *  indivisible (modulo 'break_long_words'), but a line break can
+         *  come between any two chunks.  Chunks should not have internal
+         *  whitespace; ie. a chunk is either all whitespace or a "word".
+         *  Whitespace chunks will be removed from the beginning and end of
+         *  lines, but apart from that whitespace is preserved.
+         */
+        let lines = []
+        let indent
+        if (this.width <= 0) {
+            throw Error(`invalid width ${this.width} (must be > 0)`)
+        }
+        if (this.max_lines !== undefined) {
+            if (this.max_lines > 1) {
+                indent = this.subsequent_indent
+            } else {
+                indent = this.initial_indent
+            }
+            if (indent.length + this.placeholder.trimStart().length > this.width) {
+                throw Error('placeholder too large for max width')
+            }
+        }
+
+        // Arrange in reverse order so items can be efficiently popped
+        // from a stack of chucks.
+        chunks = chunks.reverse()
+
+        while (chunks.length > 0) {
+
+            // Start the list of chunks that will make up the current line.
+            // cur_len is just the length of all the chunks in cur_line.
+            let cur_line = []
+            let cur_len = 0
+
+            // Figure out which static string will prefix this line.
+            let indent
+            if (lines) {
+                indent = this.subsequent_indent
+            } else {
+                indent = this.initial_indent
+            }
+
+            // Maximum width for this line.
+            let width = this.width - indent.length
+
+            // First chunk on line is whitespace -- drop it, unless this
+            // is the very beginning of the text (ie. no lines started yet).
+            if (this.drop_whitespace && chunks[chunks.length - 1].trim() === '' && lines.length > 0) {
+                chunks.pop()
+            }
+
+            while (chunks.length > 0) {
+                let l = chunks[chunks.length - 1].length
+
+                // Can at least squeeze this chunk onto the current line.
+                if (cur_len + l <= width) {
+                    cur_line.push(chunks.pop())
+                    cur_len += l
+
+                // Nope, this line is full.
+                } else {
+                    break
+                }
+            }
+
+            // The current line is full, and the next chunk is too big to
+            // fit on *any* line (not just this one).
+            if (chunks.length && chunks[chunks.length - 1].length > width) {
+                this._handle_long_word(chunks, cur_line, cur_len, width)
+                cur_len = cur_line.map(l => l.length).reduce((a, b) => a + b, 0)
+            }
+
+            // If the last chunk on this line is all whitespace, drop it.
+            if (this.drop_whitespace && cur_line.length > 0 && cur_line[cur_line.length - 1].trim() === '') {
+                cur_len -= cur_line[cur_line.length - 1].length
+                cur_line.pop()
+            }
+
+            if (cur_line) {
+                if (this.max_lines === undefined ||
+                    lines.length + 1 < this.max_lines ||
+                    (chunks.length === 0 ||
+                     this.drop_whitespace &&
+                     chunks.length === 1 &&
+                     !chunks[0].trim()) && cur_len <= width) {
+                    // Convert current line back to a string and store it in
+                    // list of all lines (return value).
+                    lines.push(indent + cur_line.join(''))
+                } else {
+                    let had_break = false
+                    while (cur_line) {
+                        if (cur_line[cur_line.length - 1].trim() &&
+                            cur_len + this.placeholder.length <= width) {
+                            cur_line.push(this.placeholder)
+                            lines.push(indent + cur_line.join(''))
+                            had_break = true
+                            break
+                        }
+                        cur_len -= cur_line[-1].length
+                        cur_line.pop()
+                    }
+                    if (!had_break) {
+                        if (lines) {
+                            let prev_line = lines[lines.length - 1].trimEnd()
+                            if (prev_line.length + this.placeholder.length <=
+                                    this.width) {
+                                lines[lines.length - 1] = prev_line + this.placeholder
+                                break
+                            }
+                        }
+                        lines.push(indent + this.placeholder.lstrip())
+                    }
+                    break
+                }
+            }
+        }
+
+        return lines
+    }
+
+    _split_chunks(text) {
+        text = this._munge_whitespace(text)
+        return this._split(text)
+    }
+
+    // -- Public interface ----------------------------------------------
+
+    wrap(text) {
+        /*
+         *  wrap(text : string) -> [string]
+         *
+         *  Reformat the single paragraph in 'text' so it fits in lines of
+         *  no more than 'self.width' columns, and return a list of wrapped
+         *  lines.  Tabs in 'text' are expanded with string.expandtabs(),
+         *  and all other whitespace characters (including newline) are
+         *  converted to space.
+         */
+        let chunks = this._split_chunks(text)
+        // not implemented in js
+        //if (this.fix_sentence_endings) {
+        //    this._fix_sentence_endings(chunks)
+        //}
+        return this._wrap_chunks(chunks)
+    }
+
+    fill(text) {
+        /*
+         *  fill(text : string) -> string
+         *
+         *  Reformat the single paragraph in 'text' to fit in lines of no
+         *  more than 'self.width' columns, and return a new string
+         *  containing the entire wrapped paragraph.
+         */
+        return this.wrap(text).join('\n')
+    }
+}
+
+
+// -- Convenience interface ---------------------------------------------
+
+function wrap(text, options = {}) {
+    /*
+     *  Wrap a single paragraph of text, returning a list of wrapped lines.
+     *
+     *  Reformat the single paragraph in 'text' so it fits in lines of no
+     *  more than 'width' columns, and return a list of wrapped lines.  By
+     *  default, tabs in 'text' are expanded with string.expandtabs(), and
+     *  all other whitespace characters (including newline) are converted to
+     *  space.  See TextWrapper class for available keyword args to customize
+     *  wrapping behaviour.
+     */
+    let { width = 70, ...kwargs } = options
+    let w = new TextWrapper(Object.assign({ width }, kwargs))
+    return w.wrap(text)
+}
+
+function fill(text, options = {}) {
+    /*
+     *  Fill a single paragraph of text, returning a new string.
+     *
+     *  Reformat the single paragraph in 'text' to fit in lines of no more
+     *  than 'width' columns, and return a new string containing the entire
+     *  wrapped paragraph.  As with wrap(), tabs are expanded and other
+     *  whitespace characters converted to space.  See TextWrapper class for
+     *  available keyword args to customize wrapping behaviour.
+     */
+    let { width = 70, ...kwargs } = options
+    let w = new TextWrapper(Object.assign({ width }, kwargs))
+    return w.fill(text)
+}
+
+// -- Loosely related functionality -------------------------------------
+
+let _whitespace_only_re = /^[ \t]+$/mg
+let _leading_whitespace_re = /(^[ \t]*)(?:[^ \t\n])/mg
+
+function dedent(text) {
+    /*
+     *  Remove any common leading whitespace from every line in `text`.
+     *
+     *  This can be used to make triple-quoted strings line up with the left
+     *  edge of the display, while still presenting them in the source code
+     *  in indented form.
+     *
+     *  Note that tabs and spaces are both treated as whitespace, but they
+     *  are not equal: the lines "  hello" and "\\thello" are
+     *  considered to have no common leading whitespace.
+     *
+     *  Entirely blank lines are normalized to a newline character.
+     */
+    // Look for the longest leading string of spaces and tabs common to
+    // all lines.
+    let margin = undefined
+    text = text.replace(_whitespace_only_re, '')
+    let indents = text.match(_leading_whitespace_re) || []
+    for (let indent of indents) {
+        indent = indent.slice(0, -1)
+
+        if (margin === undefined) {
+            margin = indent
+
+        // Current line more deeply indented than previous winner:
+        // no change (previous winner is still on top).
+        } else if (indent.startsWith(margin)) {
+            // pass
+
+        // Current line consistent with and no deeper than previous winner:
+        // it's the new winner.
+        } else if (margin.startsWith(indent)) {
+            margin = indent
+
+        // Find the largest common whitespace between current line and previous
+        // winner.
+        } else {
+            for (let i = 0; i < margin.length && i < indent.length; i++) {
+                if (margin[i] !== indent[i]) {
+                    margin = margin.slice(0, i)
+                    break
+                }
+            }
+        }
+    }
+
+    if (margin) {
+        text = text.replace(new RegExp('^' + margin, 'mg'), '')
+    }
+    return text
+}
+
+module.exports = { wrap, fill, dedent }

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/package.json
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/argparse/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "argparse",
+  "description": "CLI arguments parser. Native port of python's argparse.",
+  "version": "2.0.1",
+  "keywords": [
+    "cli",
+    "parser",
+    "argparse",
+    "option",
+    "args"
+  ],
+  "main": "argparse.js",
+  "files": [
+    "argparse.js",
+    "lib/"
+  ],
+  "license": "Python-2.0",
+  "repository": "nodeca/argparse",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "npm run lint && nyc mocha",
+    "coverage": "npm run test && nyc report --reporter html"
+  },
+  "devDependencies": {
+    "@babel/eslint-parser": "^7.11.0",
+    "@babel/plugin-syntax-class-properties": "^7.10.4",
+    "eslint": "^7.5.0",
+    "mocha": "^8.0.1",
+    "nyc": "^15.1.0"
+  }
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/LICENSE
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/LICENSE
@@ -1,0 +1,21 @@
+(The MIT License)
+
+Copyright (C) 2011-2015 by Vitaly Puzrin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/README.md
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/README.md
@@ -1,0 +1,211 @@
+JS-YAML - YAML 1.2 parser / writer for JavaScript
+=================================================
+
+[![CI](https://github.com/nodeca/js-yaml/actions/workflows/ci.yml/badge.svg)](https://github.com/nodeca/js-yaml/actions/workflows/ci.yml)
+[![NPM version](https://img.shields.io/npm/v/js-yaml.svg)](https://www.npmjs.org/package/js-yaml)
+
+__[Online Demo](https://nodeca.github.io/js-yaml/)__
+
+
+A fast and complete [YAML](https://yaml.org/) parser and writer for JavaScript.
+Supports both the 1.2 and 1.1 specs, and passes the entire
+[YAML Test Suite](https://github.com/yaml/yaml-test-suite).
+
+
+Installation
+------------
+
+```
+npm install js-yaml
+```
+
+Upgrading from v4? See the [v5 migration guide](docs/migrate_v4_to_v5.md).
+
+
+API
+---
+
+Here we cover the most useful methods. If you need advanced details (such as
+creating your own tags), see the [examples](examples/) for more info.
+
+``` javascript
+import { load } from 'js-yaml'
+import { readFileSync } from 'node:fs'
+
+// Get document, or throw exception on error
+try {
+  const doc = load(readFileSync('example.yml', 'utf8'))
+  console.log(doc)
+} catch (e) {
+  console.log(e)
+}
+```
+
+
+### load (string [ , options ])
+
+Parses `string` as a single YAML document. Throws `YAMLException` on error.
+This function **does not** understand multi-document or empty sources; it throws
+an exception on those.
+
+> [!WARNING]
+> When processing untrusted input, see the
+> [security considerations](docs/safety.md).
+
+options:
+
+- `filename` _(default: null)_ - string to be used as a file path in
+  error/warning messages.
+- `schema` _(default: `CORE_SCHEMA`)_ - specifies a schema to use.
+  - `FAILSAFE_SCHEMA` - only strings, arrays and plain objects.
+  - `JSON_SCHEMA` - all JSON-supported types.
+  - `CORE_SCHEMA` - a superset of `JSON_SCHEMA`, accepting more notations for
+    the same types.
+  - `YAML11_SCHEMA` - adds the legacy YAML 1.1 types (`!!binary`, `!!timestamp`,
+    `!!omap`, `!!pairs`, `!!set`, merge keys `<<`, and the broader 1.1 scalar
+    notations).
+- `json` _(default: false)_ - compatibility with `JSON.parse` behaviour. If
+  `true`, duplicate keys in a mapping override values rather than throwing an
+  error.
+- `maxDepth` _(default: 100)_ - limits the nesting depth for collections (does
+  not take aliases into account).
+- `maxTotalMergeKeys` _(default: 10000)_ - limits the total number of keys
+  processed by merge (`<<`) across one `load()` / `loadAll()` call. Set to `-1`
+  to disable.
+- `maxAliases` _(default: -1)_ - limits the number of alias nodes (`*ref`) per
+  document. Set to `0` to reject all aliases, or to `-1` for no limit.
+
+> [!NOTE]
+>
+> The default `CORE_SCHEMA` comes without the `!!merge` tag. You can easily
+> enable it if needed:
+>
+> ``` javascript
+> import { load, CORE_SCHEMA, mergeTag } from 'js-yaml'
+>
+> load(data, { schema: CORE_SCHEMA.withTags(mergeTag) })
+> ```
+
+> [!WARNING]
+>
+> The default `mapTag` is `{}`-object based and does not allow complex keys
+> (objects, arrays and so on). That's an intentional choice for convenience.
+> Also, non-string scalar keys, such as `null`, numbers or booleans, are
+> converted to strings.
+>
+> In the rare cases where you really need complex keys, use `realMapTag` in the
+> schema instead. It stores any key exactly as provided, at the cost of less
+> convenient access.
+
+See [examples](examples/) for advanced customization approaches.
+
+
+### loadAll (string [, options ])
+
+Same as `load()`, but understands multi-document sources. Returns an array of
+documents.
+
+``` javascript
+import { loadAll } from 'js-yaml'
+
+console.log(loadAll(data))
+```
+
+
+### dump (object [ , options ])
+
+Serializes `object` as a YAML document. By default it can dump every supported
+YAML type, so it throws an exception if you try to dump regexps or functions.
+However, you can disable exceptions by setting the `skipInvalid` option to
+`true`.
+
+options:
+
+- `indent` _(default: 2)_ - indentation width to use (in spaces).
+- `flowLevel` _(default: -1)_ - nesting level at which collections switch from
+  block to flow style (`-1` means never).
+- `seqNoIndent` _(default: false)_ - when `true`, does not add an indentation
+  level to array elements, `␣␣- 1` => `- 1`.
+- `seqInlineFirst` _(default: true)_ - when `true`, allows a nested collection
+  to start on the same line after `-`, `-\n  - 1` => `- - 1`.
+- `skipInvalid` _(default: false)_ - do not throw on invalid types (such as a
+  function in the schema). Invalid mapping pairs and sequence items are skipped;
+  `undefined` sequence items are serialized as `null`.
+- `schema` _(default: a `YAML11_SCHEMA`-based schema)_ - specifies a schema to
+  use.
+- `sortKeys` _(default: `false`)_ - if `true`, sort keys when dumping YAML. If a
+  function, use the function to sort the keys.
+- `lineWidth` _(default: `80`)_ - sets the max line width. Set `-1` for unlimited
+  width.
+- `noRefs` _(default: `false`)_ - if `true`, don't convert duplicate objects into
+  references; inline them instead.
+- `quoteStyle` _(`single` or `double`, default: `single`)_ - quoting style to use
+  when a string needs quotes.
+- `forceQuotes` _(default: `false`)_ - if `true`, quote all non-key strings,
+  using `quoteStyle`.
+- `flowBracketPadding` _(default: `false`)_ - add spaces inside flow collection
+  brackets, `{a: 1}` => `{ a: 1 }`.
+- `flowSkipCommaSpace` _(default: `false`)_ - omit the space after commas in
+  flow collections, `[1, 2]` => `[1,2]`.
+- `flowSkipColonSpace` _(default: `false`)_ - omit the space after `:` in flow
+  mappings, `{a: 1}` => `{a:1}`.
+- `quoteFlowKeys` _(default: `false`)_ - quote flow mapping keys, `{a: 1}` =>
+  `{"a": 1}`.
+- `tagBeforeAnchor` _(default: `false`)_ - print an explicit tag before an
+  anchor, `&ref_0 !!set` => `!!set &ref_0`.
+- `transform` - a function `(documents: Document[]) => void` that can mutate the
+  generated AST before it is rendered.
+
+See [examples](examples/) for advanced customization approaches.
+
+
+Supported YAML types
+--------------------
+
+The list of standard YAML tags and corresponding JavaScript types. See also
+[YAML tag discussion](https://pyyaml.org/wiki/YAMLTagDiscussion) and
+[YAML types repository](https://yaml.org/type/).
+
+```
+!!null ''                   # null
+!!bool 'true'               # bool
+!!int '3...'                # number
+!!float '3.14...'           # number
+!!str '...'                 # string
+!!seq [ ... ]               # array
+!!map { ... }               # object (or Map)
+```
+
+The types below are only available in `YAML11_SCHEMA` (not in the default
+`CORE_SCHEMA`):
+
+```
+!!binary '...base64...'     # Uint8Array
+!!timestamp 'YYYY-...'      # date
+!!set { ... }               # Set
+
+# Legacy YAML 1.1 compatibility only; these types cannot be dumped.
+!!omap [ ... ]              # array of key-value pairs
+!!pairs [ ... ]             # array of array pairs
+```
+
+To preserve complex keys in the first position of a `!!pairs` item, replace
+the default object-based map with `realMapTag` in the schema.
+
+**JavaScript-specific tags**
+
+See [js-yaml-js-types](https://github.com/nodeca/js-yaml-js-types) for
+extra types.
+
+
+CLI
+---
+
+This can be useful sometimes for a quick check.
+
+```
+npx js-yaml -h
+```
+
+Note: the CLI script comes with minimal options, and there are no big plans to
+extend it.

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/dist/js-yaml.cjs.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/dist/js-yaml.cjs.js
@@ -1,0 +1,3265 @@
+/*! js-yaml 5.2.3 https://github.com/nodeca/js-yaml @license MIT */
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+//#region src/tag.ts
+var NOT_RESOLVED = Symbol("NOT_RESOLVED");
+var MERGE_KEY = Symbol("MERGE_KEY");
+function defineScalarTag(tagName, options) {
+	var _options$implicit, _options$matchByTagPr, _options$implicitFirs, _options$identify, _options$represent, _options$representTag;
+	return {
+		tagName,
+		nodeKind: "scalar",
+		implicit: (_options$implicit = options.implicit) !== null && _options$implicit !== void 0 ? _options$implicit : false,
+		matchByTagPrefix: (_options$matchByTagPr = options.matchByTagPrefix) !== null && _options$matchByTagPr !== void 0 ? _options$matchByTagPr : false,
+		implicitFirstChars: (_options$implicitFirs = options.implicitFirstChars) !== null && _options$implicitFirs !== void 0 ? _options$implicitFirs : null,
+		resolve: options.resolve,
+		identify: (_options$identify = options.identify) !== null && _options$identify !== void 0 ? _options$identify : null,
+		represent: (_options$represent = options.represent) !== null && _options$represent !== void 0 ? _options$represent : ((data) => String(data)),
+		representTagName: (_options$representTag = options.representTagName) !== null && _options$representTag !== void 0 ? _options$representTag : null
+	};
+}
+function defineSequenceTag(tagName, options) {
+	var _options$matchByTagPr2, _options$finalize, _options$identify2, _options$represent2, _options$representTag2;
+	const carrierIsResult = options.finalize === void 0;
+	return {
+		tagName,
+		nodeKind: "sequence",
+		implicit: false,
+		matchByTagPrefix: (_options$matchByTagPr2 = options.matchByTagPrefix) !== null && _options$matchByTagPr2 !== void 0 ? _options$matchByTagPr2 : false,
+		create: options.create,
+		addItem: options.addItem,
+		finalize: (_options$finalize = options.finalize) !== null && _options$finalize !== void 0 ? _options$finalize : ((carrier) => carrier),
+		carrierIsResult,
+		identify: (_options$identify2 = options.identify) !== null && _options$identify2 !== void 0 ? _options$identify2 : null,
+		represent: (_options$represent2 = options.represent) !== null && _options$represent2 !== void 0 ? _options$represent2 : ((data) => data),
+		representTagName: (_options$representTag2 = options.representTagName) !== null && _options$representTag2 !== void 0 ? _options$representTag2 : null
+	};
+}
+function defineMappingTag(tagName, options) {
+	var _options$matchByTagPr3, _options$finalize2, _options$identify3, _options$represent3, _options$representTag3;
+	const carrierIsResult = options.finalize === void 0;
+	return {
+		tagName,
+		nodeKind: "mapping",
+		implicit: false,
+		matchByTagPrefix: (_options$matchByTagPr3 = options.matchByTagPrefix) !== null && _options$matchByTagPr3 !== void 0 ? _options$matchByTagPr3 : false,
+		create: options.create,
+		addPair: options.addPair,
+		has: options.has,
+		keys: options.keys,
+		get: options.get,
+		finalize: (_options$finalize2 = options.finalize) !== null && _options$finalize2 !== void 0 ? _options$finalize2 : ((carrier) => carrier),
+		carrierIsResult,
+		identify: (_options$identify3 = options.identify) !== null && _options$identify3 !== void 0 ? _options$identify3 : null,
+		represent: (_options$represent3 = options.represent) !== null && _options$represent3 !== void 0 ? _options$represent3 : ((data) => data),
+		representTagName: (_options$representTag3 = options.representTagName) !== null && _options$representTag3 !== void 0 ? _options$representTag3 : null
+	};
+}
+//#endregion
+//#region src/tag/scalar/str.ts
+var strTag = defineScalarTag("tag:yaml.org,2002:str", {
+	resolve: (source) => source,
+	identify: (data) => typeof data === "string"
+});
+//#endregion
+//#region src/tag/scalar/null_core.ts
+var NULL_VALUES$1 = [
+	"",
+	"~",
+	"null",
+	"Null",
+	"NULL"
+];
+var nullCoreTag = defineScalarTag("tag:yaml.org,2002:null", {
+	implicit: true,
+	implicitFirstChars: [
+		"",
+		"~",
+		"n",
+		"N"
+	],
+	resolve: (source) => {
+		if (NULL_VALUES$1.indexOf(source) !== -1) return null;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => object === null,
+	represent: () => "null"
+});
+//#endregion
+//#region src/tag/scalar/null_json.ts
+var nullJsonTag = defineScalarTag("tag:yaml.org,2002:null", {
+	implicit: true,
+	implicitFirstChars: ["n"],
+	resolve: (source, isExplicit) => {
+		if (source === "null" || isExplicit && source === "") return null;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => object === null,
+	represent: () => "null"
+});
+//#endregion
+//#region src/tag/scalar/null_yaml11.ts
+var NULL_VALUES = [
+	"",
+	"~",
+	"null",
+	"Null",
+	"NULL"
+];
+var nullYaml11Tag = defineScalarTag("tag:yaml.org,2002:null", {
+	implicit: true,
+	implicitFirstChars: [
+		"",
+		"~",
+		"n",
+		"N"
+	],
+	resolve: (source) => {
+		if (NULL_VALUES.indexOf(source) !== -1) return null;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => object === null,
+	represent: () => "null"
+});
+//#endregion
+//#region src/tag/scalar/bool_core.ts
+var TRUE_VALUES$2 = [
+	"true",
+	"True",
+	"TRUE"
+];
+var FALSE_VALUES$2 = [
+	"false",
+	"False",
+	"FALSE"
+];
+var boolCoreTag = defineScalarTag("tag:yaml.org,2002:bool", {
+	implicit: true,
+	implicitFirstChars: [
+		"t",
+		"T",
+		"f",
+		"F"
+	],
+	resolve: (source) => {
+		if (TRUE_VALUES$2.indexOf(source) !== -1) return true;
+		if (FALSE_VALUES$2.indexOf(source) !== -1) return false;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => Object.prototype.toString.call(object) === "[object Boolean]",
+	represent: (object) => object ? "true" : "false"
+});
+//#endregion
+//#region src/tag/scalar/bool_json.ts
+var TRUE_VALUES$1 = ["true"];
+var FALSE_VALUES$1 = ["false"];
+var boolJsonTag = defineScalarTag("tag:yaml.org,2002:bool", {
+	implicit: true,
+	implicitFirstChars: ["t", "f"],
+	resolve: (source) => {
+		if (TRUE_VALUES$1.indexOf(source) !== -1) return true;
+		if (FALSE_VALUES$1.indexOf(source) !== -1) return false;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => Object.prototype.toString.call(object) === "[object Boolean]",
+	represent: (object) => object ? "true" : "false"
+});
+//#endregion
+//#region src/tag/scalar/bool_yaml11.ts
+var TRUE_VALUES = [
+	"true",
+	"True",
+	"TRUE",
+	"y",
+	"Y",
+	"yes",
+	"Yes",
+	"YES",
+	"on",
+	"On",
+	"ON"
+];
+var FALSE_VALUES = [
+	"false",
+	"False",
+	"FALSE",
+	"n",
+	"N",
+	"no",
+	"No",
+	"NO",
+	"off",
+	"Off",
+	"OFF"
+];
+var boolYaml11Tag = defineScalarTag("tag:yaml.org,2002:bool", {
+	implicit: true,
+	implicitFirstChars: [
+		"y",
+		"Y",
+		"n",
+		"N",
+		"t",
+		"T",
+		"f",
+		"F",
+		"o",
+		"O"
+	],
+	resolve: (source) => {
+		if (TRUE_VALUES.indexOf(source) !== -1) return true;
+		if (FALSE_VALUES.indexOf(source) !== -1) return false;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => Object.prototype.toString.call(object) === "[object Boolean]",
+	represent: (object) => object ? "true" : "false"
+});
+//#endregion
+//#region src/tag/scalar/int_core.ts
+var YAML_INTEGER_IMPLICIT_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:0o[0-7]+|0x[0-9a-fA-F]+|[-+]?[0-9]+)$");
+var YAML_INTEGER_EXPLICIT_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:[-+]?0b[0-1]+|[-+]?0o[0-7]+|[-+]?0x[0-9a-fA-F]+|[-+]?[0-9]+)$");
+function parseYamlInteger$2(source) {
+	let value = source;
+	let sign = 1;
+	if (value[0] === "-" || value[0] === "+") {
+		if (value[0] === "-") sign = -1;
+		value = value.slice(1);
+	}
+	if (value.startsWith("0b")) return sign * parseInt(value.slice(2), 2);
+	if (value.startsWith("0o")) return sign * parseInt(value.slice(2), 8);
+	if (value.startsWith("0x")) return sign * parseInt(value.slice(2), 16);
+	return sign * parseInt(value, 10);
+}
+function resolveYamlInteger$2(source, isExplicit) {
+	if (isExplicit) {
+		if (!YAML_INTEGER_EXPLICIT_PATTERN$1.test(source)) return NOT_RESOLVED;
+	} else if (!YAML_INTEGER_IMPLICIT_PATTERN$1.test(source)) return NOT_RESOLVED;
+	const result = parseYamlInteger$2(source);
+	return Number.isFinite(result) ? result : NOT_RESOLVED;
+}
+var intCoreTag = defineScalarTag("tag:yaml.org,2002:int", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		..."0123456789"
+	],
+	resolve: resolveYamlInteger$2,
+	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	represent: (object) => object.toString(10)
+});
+//#endregion
+//#region src/tag/scalar/int_json.ts
+var YAML_INTEGER_IMPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^-?(?:0|[1-9][0-9]*)$");
+var YAML_INTEGER_EXPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?0b[0-1]+|[-+]?0o[0-7]+|[-+]?0x[0-9a-fA-F]+|[-+]?[0-9]+)$");
+function parseYamlInteger$1(source) {
+	let value = source;
+	let sign = 1;
+	if (value[0] === "-" || value[0] === "+") {
+		if (value[0] === "-") sign = -1;
+		value = value.slice(1);
+	}
+	if (value.startsWith("0b")) return sign * parseInt(value.slice(2), 2);
+	if (value.startsWith("0o")) return sign * parseInt(value.slice(2), 8);
+	if (value.startsWith("0x")) return sign * parseInt(value.slice(2), 16);
+	return sign * parseInt(value, 10);
+}
+function resolveYamlInteger$1(source, isExplicit) {
+	if (isExplicit) {
+		if (!YAML_INTEGER_EXPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+	} else if (!YAML_INTEGER_IMPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+	const result = parseYamlInteger$1(source);
+	return Number.isFinite(result) ? result : NOT_RESOLVED;
+}
+var intJsonTag = defineScalarTag("tag:yaml.org,2002:int", {
+	implicit: true,
+	implicitFirstChars: ["-", ..."0123456789"],
+	resolve: resolveYamlInteger$1,
+	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	represent: (object) => object.toString(10)
+});
+//#endregion
+//#region src/tag/scalar/int_yaml11.ts
+var YAML_INTEGER_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?0x[0-9a-fA-F_]+|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+|[-+]?(?:0|[1-9][0-9_]*))$");
+function parseYamlInteger(source) {
+	let value = source.replace(/_/g, "");
+	let sign = 1;
+	if (value[0] === "-" || value[0] === "+") {
+		if (value[0] === "-") sign = -1;
+		value = value.slice(1);
+	}
+	if (value.startsWith("0b")) return sign * parseInt(value.slice(2), 2);
+	if (value.startsWith("0x")) return sign * parseInt(value.slice(2), 16);
+	if (value.includes(":")) {
+		let result = 0;
+		for (const part of value.split(":")) result = result * 60 + Number(part);
+		return sign * result;
+	}
+	if (value !== "0" && value[0] === "0") return sign * parseInt(value, 8);
+	return sign * parseInt(value, 10);
+}
+function resolveYamlInteger(source) {
+	if (!YAML_INTEGER_PATTERN.test(source)) return NOT_RESOLVED;
+	const result = parseYamlInteger(source);
+	return Number.isFinite(result) ? result : NOT_RESOLVED;
+}
+var intYaml11Tag = defineScalarTag("tag:yaml.org,2002:int", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		..."0123456789"
+	],
+	resolve: resolveYamlInteger,
+	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	represent: (object) => object.toString(10)
+});
+//#endregion
+//#region src/tag/scalar/float_core.ts
+var YAML_FLOAT_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:[-+]?[0-9]+(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?|[-+]?\\.[0-9]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+var YAML_FLOAT_SPECIAL_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+function resolveYamlFloat$2(source) {
+	if (!YAML_FLOAT_PATTERN$1.test(source)) return NOT_RESOLVED;
+	let value = source.toLowerCase();
+	const sign = value[0] === "-" ? -1 : 1;
+	if ("+-".includes(value[0])) value = value.slice(1);
+	if (value === ".inf") return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+	if (value === ".nan") return NaN;
+	const result = sign * parseFloat(value);
+	if (Number.isFinite(result) || YAML_FLOAT_SPECIAL_PATTERN$1.test(source)) return result;
+	return NOT_RESOLVED;
+}
+function representYamlFloat$2(object) {
+	if (isNaN(object)) return ".nan";
+	if (object === Number.POSITIVE_INFINITY) return ".inf";
+	if (object === Number.NEGATIVE_INFINITY) return "-.inf";
+	if (Object.is(object, -0)) return "-0.0";
+	const result = object.toString(10);
+	return /^[-+]?[0-9]+e/.test(result) ? result.replace("e", ".e") : result;
+}
+var floatCoreTag = defineScalarTag("tag:yaml.org,2002:float", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		".",
+		..."0123456789"
+	],
+	resolve: resolveYamlFloat$2,
+	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	represent: representYamlFloat$2
+});
+//#endregion
+//#region src/tag/scalar/float_json.ts
+var YAML_FLOAT_IMPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^-?(?:0|[1-9][0-9]*)(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?$");
+var YAML_FLOAT_EXPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?[0-9]+(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?|[-+]?\\.[0-9]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+function resolveYamlFloat$1(source, isExplicit) {
+	if (isExplicit) {
+		if (!YAML_FLOAT_EXPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+		let value = source.toLowerCase();
+		const sign = value[0] === "-" ? -1 : 1;
+		if ("+-".includes(value[0])) value = value.slice(1);
+		if (value === ".inf") return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+		if (value === ".nan") return NaN;
+		const result = sign * parseFloat(value);
+		return Number.isFinite(result) ? result : NOT_RESOLVED;
+	}
+	if (!YAML_FLOAT_IMPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+	const result = Number(source);
+	if (Number.isFinite(result)) return result;
+	return NOT_RESOLVED;
+}
+function representYamlFloat$1(object) {
+	if (isNaN(object)) return ".nan";
+	if (object === Number.POSITIVE_INFINITY) return ".inf";
+	if (object === Number.NEGATIVE_INFINITY) return "-.inf";
+	if (Object.is(object, -0)) return "-0.0";
+	const result = object.toString(10);
+	return /^[-+]?[0-9]+e/.test(result) ? result.replace("e", ".e") : result;
+}
+var floatJsonTag = defineScalarTag("tag:yaml.org,2002:float", {
+	implicit: true,
+	implicitFirstChars: ["-", ..."0123456789"],
+	resolve: resolveYamlFloat$1,
+	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	represent: representYamlFloat$1
+});
+//#endregion
+//#region src/tag/scalar/float_yaml11.ts
+var YAML_FLOAT_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?(?:(?:[0-9][0-9_]*)?\\.[0-9_]*)(?:[eE][-+][0-9]+)?|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+var YAML_FLOAT_SPECIAL_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+function resolveYamlFloat(source) {
+	if (!YAML_FLOAT_PATTERN.test(source)) return NOT_RESOLVED;
+	let value = source.toLowerCase().replace(/_/g, "");
+	const sign = value[0] === "-" ? -1 : 1;
+	if ("+-".includes(value[0])) value = value.slice(1);
+	if (value === ".inf") return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+	if (value === ".nan") return NaN;
+	let result = 0;
+	if (value.includes(":")) {
+		for (const part of value.split(":")) result = result * 60 + Number(part);
+		result *= sign;
+	} else result = sign * parseFloat(value);
+	if (Number.isFinite(result) || YAML_FLOAT_SPECIAL_PATTERN.test(source)) return result;
+	return NOT_RESOLVED;
+}
+function representYamlFloat(object) {
+	if (isNaN(object)) return ".nan";
+	if (object === Number.POSITIVE_INFINITY) return ".inf";
+	if (object === Number.NEGATIVE_INFINITY) return "-.inf";
+	if (Object.is(object, -0)) return "-0.0";
+	const result = object.toString(10);
+	return /^[-+]?[0-9]+e/.test(result) ? result.replace("e", ".e") : result;
+}
+var floatYaml11Tag = defineScalarTag("tag:yaml.org,2002:float", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		".",
+		..."0123456789"
+	],
+	resolve: resolveYamlFloat,
+	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	represent: representYamlFloat
+});
+//#endregion
+//#region src/tag/scalar/merge.ts
+var mergeTag = defineScalarTag("tag:yaml.org,2002:merge", {
+	implicit: true,
+	implicitFirstChars: ["<"],
+	resolve: (source, isExplicit) => {
+		if (source === "<<" || isExplicit && source === "") return MERGE_KEY;
+		return NOT_RESOLVED;
+	}
+});
+//#endregion
+//#region src/tag/scalar/binary.ts
+var BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/;
+function resolveYamlBinary(source) {
+	const input = source.replace(/\s/g, "");
+	if (input.length % 4 !== 0 || !BASE64_PATTERN.test(input)) return NOT_RESOLVED;
+	const binary = atob(input);
+	const result = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index++) result[index] = binary.charCodeAt(index);
+	return result;
+}
+function representYamlBinary(object) {
+	let binary = "";
+	for (let index = 0; index < object.length; index++) binary += String.fromCharCode(object[index]);
+	return btoa(binary);
+}
+var binaryTag = defineScalarTag("tag:yaml.org,2002:binary", {
+	resolve: resolveYamlBinary,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Uint8Array]",
+	represent: representYamlBinary
+});
+//#endregion
+//#region src/tag/scalar/timestamp.ts
+var YAML_DATE_REGEXP = /* @__PURE__ */ new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$");
+var YAML_TIMESTAMP_REGEXP = /* @__PURE__ */ new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$");
+function makeUtcDate(year, month, day, hour = 0, minute = 0, second = 0, fraction = 0) {
+	const date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+	date.setUTCFullYear(year, month, day);
+	return date;
+}
+function resolveYamlTimestamp(source) {
+	let match = YAML_DATE_REGEXP.exec(source);
+	if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(source);
+	if (match === null) return NOT_RESOLVED;
+	const year = +match[1];
+	const month = +match[2] - 1;
+	const day = +match[3];
+	if (!match[4]) {
+		const date = makeUtcDate(year, month, day);
+		if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) return NOT_RESOLVED;
+		return date;
+	}
+	const hour = +match[4];
+	const minute = +match[5];
+	const second = +match[6];
+	let fraction = 0;
+	if (hour > 23 || minute > 59 || second > 59) return NOT_RESOLVED;
+	if (match[7]) {
+		let value = match[7].slice(0, 3);
+		while (value.length < 3) value += "0";
+		fraction = +value;
+	}
+	const date = makeUtcDate(year, month, day, hour, minute, second, fraction);
+	if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) return NOT_RESOLVED;
+	if (match[9]) {
+		const offsetHour = +match[10];
+		const offsetMinute = +(match[11] || 0);
+		if (offsetHour > 23 || offsetMinute > 59) return NOT_RESOLVED;
+		const offset = (offsetHour * 60 + offsetMinute) * 6e4;
+		date.setTime(date.getTime() - (match[9] === "-" ? -offset : offset));
+	}
+	return date;
+}
+var timestampTag = defineScalarTag("tag:yaml.org,2002:timestamp", {
+	implicit: true,
+	implicitFirstChars: [..."0123456789"],
+	resolve: resolveYamlTimestamp,
+	identify: (object) => object instanceof Date,
+	represent: (object) => object.toISOString()
+});
+//#endregion
+//#region src/tag/sequence/seq.ts
+var seqTag = defineSequenceTag("tag:yaml.org,2002:seq", {
+	create: () => [],
+	addItem: (container, item) => {
+		container.push(item);
+	},
+	identify: Array.isArray
+});
+//#endregion
+//#region src/common/object.ts
+function isPlainObject(data) {
+	if (data === null || typeof data !== "object" || Array.isArray(data)) return false;
+	const prototype = Object.getPrototypeOf(data);
+	return prototype === null || prototype === Object.prototype;
+}
+function pick(object, keys) {
+	const result = {};
+	for (const key of keys) if (object[key] !== void 0) result[key] = object[key];
+	return result;
+}
+//#endregion
+//#region src/tag/sequence/omap.ts
+var omapTag = defineSequenceTag("tag:yaml.org,2002:omap", {
+	create: () => ({
+		list: [],
+		seen: /* @__PURE__ */ new Set()
+	}),
+	addItem: (carrier, item) => {
+		let key;
+		if (item instanceof Map) {
+			if (item.size !== 1) return "cannot resolve an ordered map item";
+			key = item.keys().next().value;
+		} else if (isPlainObject(item)) {
+			const itemKeys = Object.keys(item);
+			if (itemKeys.length !== 1) return "cannot resolve an ordered map item";
+			key = itemKeys[0];
+		} else return "cannot resolve an ordered map item";
+		if (carrier.seen.has(key)) return "duplicate key in ordered map";
+		carrier.seen.add(key);
+		carrier.list.push(item);
+		return "";
+	},
+	finalize: (carrier) => carrier.list
+});
+//#endregion
+//#region src/tag/sequence/pairs.ts
+var pairsTag = defineSequenceTag("tag:yaml.org,2002:pairs", {
+	create: () => [],
+	addItem: (container, item) => {
+		if (item instanceof Map) {
+			if (item.size !== 1) return "cannot resolve a pairs item";
+			container.push(item.entries().next().value);
+			return "";
+		}
+		if (Object.prototype.toString.call(item) !== "[object Object]") return "cannot resolve a pairs item";
+		const object = item;
+		const keys = Object.keys(object);
+		if (keys.length !== 1) return "cannot resolve a pairs item";
+		container.push([keys[0], object[keys[0]]]);
+		return "";
+	}
+});
+//#endregion
+//#region src/tag/mapping/map.ts
+var mapTag = defineMappingTag("tag:yaml.org,2002:map", {
+	create: () => ({}),
+	identify: isPlainObject,
+	represent: (o) => {
+		const map = /* @__PURE__ */ new Map();
+		for (const key of Object.keys(o)) map.set(key, o[key]);
+		return map;
+	},
+	addPair: (container, key, value) => {
+		if (key !== null && typeof key === "object") return "object-based map does not support complex keys";
+		const normalizedKey = String(key);
+		if (normalizedKey === "__proto__") Object.defineProperty(container, normalizedKey, {
+			value,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		});
+		else container[normalizedKey] = value;
+		return "";
+	},
+	has: (container, key) => {
+		if (key !== null && typeof key === "object") return false;
+		return Object.prototype.hasOwnProperty.call(container, String(key));
+	},
+	keys: (container) => Object.keys(container),
+	get: (container, key) => {
+		const normalizedKey = String(key);
+		if (!Object.prototype.hasOwnProperty.call(container, normalizedKey)) return null;
+		return container[normalizedKey];
+	}
+});
+//#endregion
+//#region src/tag/mapping/set.ts
+var setTag = defineMappingTag("tag:yaml.org,2002:set", {
+	create: () => /* @__PURE__ */ new Set(),
+	identify: (data) => data instanceof Set,
+	represent: (data) => {
+		const map = /* @__PURE__ */ new Map();
+		for (const key of data) map.set(key, null);
+		return map;
+	},
+	addPair: (container, key, value) => {
+		if (value !== null) return "cannot resolve a set item";
+		container.add(key);
+		return "";
+	},
+	has: (container, key) => container.has(key),
+	keys: (container) => container.keys(),
+	get: () => null
+});
+//#endregion
+//#region \0@oxc-project+runtime@0.137.0/helpers/esm/typeof.js
+function _typeof(o) {
+	"@babel/helpers - typeof";
+	return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(o) {
+		return typeof o;
+	} : function(o) {
+		return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
+	}, _typeof(o);
+}
+//#endregion
+//#region \0@oxc-project+runtime@0.137.0/helpers/esm/toPrimitive.js
+function toPrimitive(t, r) {
+	if ("object" != _typeof(t) || !t) return t;
+	var e = t[Symbol.toPrimitive];
+	if (void 0 !== e) {
+		var i = e.call(t, r || "default");
+		if ("object" != _typeof(i)) return i;
+		throw new TypeError("@@toPrimitive must return a primitive value.");
+	}
+	return ("string" === r ? String : Number)(t);
+}
+//#endregion
+//#region \0@oxc-project+runtime@0.137.0/helpers/esm/toPropertyKey.js
+function toPropertyKey(t) {
+	var i = toPrimitive(t, "string");
+	return "symbol" == _typeof(i) ? i : i + "";
+}
+//#endregion
+//#region \0@oxc-project+runtime@0.137.0/helpers/esm/defineProperty.js
+function _defineProperty(e, r, t) {
+	return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+		value: t,
+		enumerable: !0,
+		configurable: !0,
+		writable: !0
+	}) : e[r] = t, e;
+}
+//#endregion
+//#region src/schema.ts
+function createTagDefinitionMap() {
+	return {
+		scalar: Object.create(null),
+		sequence: Object.create(null),
+		mapping: Object.create(null)
+	};
+}
+function createTagDefinitionListMap() {
+	return {
+		scalar: [],
+		sequence: [],
+		mapping: []
+	};
+}
+function compileTags(tags) {
+	const result = [];
+	for (const tag of tags) {
+		let index = result.length;
+		for (let previousIndex = 0; previousIndex < result.length; previousIndex++) {
+			const previous = result[previousIndex];
+			if (previous.nodeKind === tag.nodeKind && previous.tagName === tag.tagName && previous.matchByTagPrefix === tag.matchByTagPrefix) {
+				index = previousIndex;
+				break;
+			}
+		}
+		result[index] = tag;
+	}
+	return result;
+}
+var Schema = class Schema {
+	constructor(tags) {
+		_defineProperty(this, "tags", void 0);
+		_defineProperty(this, "implicitScalarTags", void 0);
+		_defineProperty(this, "implicitScalarByFirstChar", void 0);
+		_defineProperty(this, "implicitScalarAnyFirstChar", void 0);
+		_defineProperty(this, "defaultScalarTag", void 0);
+		_defineProperty(this, "defaultSequenceTag", void 0);
+		_defineProperty(this, "defaultMappingTag", void 0);
+		_defineProperty(this, "exact", void 0);
+		_defineProperty(this, "prefix", void 0);
+		const compiledTags = compileTags(tags);
+		const implicitScalarTags = [];
+		const exact = createTagDefinitionMap();
+		const prefix = createTagDefinitionListMap();
+		for (const tag of compiledTags) {
+			if (tag.nodeKind === "scalar" && tag.implicit) {
+				if (tag.matchByTagPrefix) throw new Error("Implicit scalar tags cannot match by tag prefix");
+				implicitScalarTags.push(tag);
+			}
+			switch (tag.nodeKind) {
+				case "scalar":
+					if (tag.matchByTagPrefix) prefix.scalar.push(tag);
+					else exact.scalar[tag.tagName] = tag;
+					break;
+				case "sequence":
+					if (tag.matchByTagPrefix) prefix.sequence.push(tag);
+					else exact.sequence[tag.tagName] = tag;
+					break;
+				case "mapping":
+					if (tag.matchByTagPrefix) prefix.mapping.push(tag);
+					else exact.mapping[tag.tagName] = tag;
+					break;
+			}
+		}
+		const implicitScalarAnyFirstChar = implicitScalarTags.filter((tag) => tag.implicitFirstChars === null);
+		const keys = /* @__PURE__ */ new Set();
+		for (const tag of implicitScalarTags) if (tag.implicitFirstChars !== null) for (const key of tag.implicitFirstChars) keys.add(key);
+		const implicitScalarByFirstChar = /* @__PURE__ */ new Map();
+		for (const key of keys) implicitScalarByFirstChar.set(key, implicitScalarTags.filter((tag) => tag.implicitFirstChars === null || tag.implicitFirstChars.indexOf(key) !== -1));
+		const defaultScalarTag = exact.scalar["tag:yaml.org,2002:str"];
+		if (!defaultScalarTag) throw new Error("schema does not define the default scalar tag (tag:yaml.org,2002:str)");
+		this.tags = compiledTags;
+		this.implicitScalarTags = implicitScalarTags;
+		this.implicitScalarByFirstChar = implicitScalarByFirstChar;
+		this.implicitScalarAnyFirstChar = implicitScalarAnyFirstChar;
+		this.defaultScalarTag = defaultScalarTag;
+		this.defaultSequenceTag = exact.sequence["tag:yaml.org,2002:seq"];
+		this.defaultMappingTag = exact.mapping["tag:yaml.org,2002:map"];
+		this.exact = exact;
+		this.prefix = prefix;
+	}
+	withTags(...tags) {
+		let flatTags = [];
+		for (const tag of tags) flatTags = flatTags.concat(tag);
+		return new Schema([...this.tags, ...flatTags]);
+	}
+};
+var FAILSAFE_SCHEMA = new Schema([
+	strTag,
+	seqTag,
+	mapTag
+]);
+var JSON_SCHEMA = new Schema([
+	...FAILSAFE_SCHEMA.tags,
+	nullJsonTag,
+	boolJsonTag,
+	intJsonTag,
+	floatJsonTag
+]);
+var CORE_SCHEMA = new Schema([
+	...FAILSAFE_SCHEMA.tags,
+	nullCoreTag,
+	boolCoreTag,
+	intCoreTag,
+	floatCoreTag
+]);
+var YAML11_SCHEMA = new Schema([
+	...FAILSAFE_SCHEMA.tags,
+	nullYaml11Tag,
+	boolYaml11Tag,
+	intYaml11Tag,
+	floatYaml11Tag,
+	timestampTag,
+	mergeTag,
+	binaryTag,
+	omapTag,
+	pairsTag,
+	setTag
+]);
+//#endregion
+//#region src/tag/mapping/real_map.ts
+var realMapTag = defineMappingTag("tag:yaml.org,2002:map", {
+	create: () => /* @__PURE__ */ new Map(),
+	addPair: (container, key, value) => {
+		container.set(key, value);
+		return "";
+	},
+	has: (container, key) => container.has(key),
+	keys: (container) => container.keys(),
+	get: (container, key) => container.get(key),
+	identify: (data) => data instanceof Map || isPlainObject(data),
+	represent: (data) => {
+		if (data instanceof Map) return data;
+		const map = /* @__PURE__ */ new Map();
+		const obj = data;
+		for (const key of Object.keys(obj)) map.set(key, obj[key]);
+		return map;
+	}
+});
+//#endregion
+//#region src/tag/mapping/legacy_map.ts
+function normalizeKey(key) {
+	if (Array.isArray(key)) {
+		const array = Array.prototype.slice.call(key);
+		for (let index = 0; index < array.length; index++) {
+			if (Array.isArray(array[index])) return null;
+			if (typeof array[index] === "object" && Object.prototype.toString.call(array[index]) === "[object Object]") array[index] = "[object Object]";
+		}
+		return String(array);
+	}
+	if (typeof key === "object" && Object.prototype.toString.call(key) === "[object Object]") return "[object Object]";
+	return String(key);
+}
+var legacyMapTag = defineMappingTag("tag:yaml.org,2002:map", {
+	create: () => ({}),
+	identify: isPlainObject,
+	represent: (o) => {
+		const map = /* @__PURE__ */ new Map();
+		for (const key of Object.keys(o)) map.set(key, o[key]);
+		return map;
+	},
+	addPair: (container, key, value) => {
+		const normalizedKey = normalizeKey(key);
+		if (normalizedKey === null) return "nested arrays are not supported inside keys";
+		if (normalizedKey === "__proto__") Object.defineProperty(container, normalizedKey, {
+			value,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		});
+		else container[normalizedKey] = value;
+		return "";
+	},
+	has: (container, key) => {
+		const normalizedKey = normalizeKey(key);
+		return normalizedKey !== null && Object.prototype.hasOwnProperty.call(container, normalizedKey);
+	},
+	keys: (container) => Object.keys(container),
+	get: (container, key) => {
+		const normalizedKey = String(key);
+		if (!Object.prototype.hasOwnProperty.call(container, normalizedKey)) return null;
+		return container[normalizedKey];
+	}
+});
+//#endregion
+//#region \0@oxc-project+runtime@0.137.0/helpers/esm/objectSpread2.js
+function ownKeys(e, r) {
+	var t = Object.keys(e);
+	if (Object.getOwnPropertySymbols) {
+		var o = Object.getOwnPropertySymbols(e);
+		r && (o = o.filter(function(r) {
+			return Object.getOwnPropertyDescriptor(e, r).enumerable;
+		})), t.push.apply(t, o);
+	}
+	return t;
+}
+function _objectSpread2(e) {
+	for (var r = 1; r < arguments.length; r++) {
+		var t = null != arguments[r] ? arguments[r] : {};
+		r % 2 ? ownKeys(Object(t), !0).forEach(function(r) {
+			_defineProperty(e, r, t[r]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function(r) {
+			Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r));
+		});
+	}
+	return e;
+}
+//#endregion
+//#region src/common/snippet.ts
+var DEFAULT_SNIPPET_OPTIONS = {
+	maxLength: 79,
+	indent: 1,
+	linesBefore: 3,
+	linesAfter: 2
+};
+function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
+	let head = "";
+	let tail = "";
+	const maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+	if (position - lineStart > maxHalfLength) {
+		head = " ... ";
+		lineStart = position - maxHalfLength + head.length;
+	}
+	if (lineEnd - position > maxHalfLength) {
+		tail = " ...";
+		lineEnd = position + maxHalfLength - tail.length;
+	}
+	return {
+		str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, "→") + tail,
+		pos: position - lineStart + head.length
+	};
+}
+function padStart(string, max) {
+	return " ".repeat(Math.max(max - string.length, 0)) + string;
+}
+function makeSnippet(mark, options) {
+	if (!mark.buffer) return null;
+	const opts = _objectSpread2(_objectSpread2({}, DEFAULT_SNIPPET_OPTIONS), options);
+	const re = /\r?\n|\r|\0/g;
+	const lineStarts = [0];
+	const lineEnds = [];
+	let match;
+	let foundLineNo = -1;
+	while (match = re.exec(mark.buffer)) {
+		lineEnds.push(match.index);
+		lineStarts.push(match.index + match[0].length);
+		if (mark.position <= match.index && foundLineNo < 0) foundLineNo = lineStarts.length - 2;
+	}
+	if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
+	let result = "";
+	const lineNoLength = Math.min(mark.line + opts.linesAfter, lineEnds.length).toString().length;
+	const maxLineLength = opts.maxLength - (opts.indent + lineNoLength + 3);
+	for (let i = 1; i <= opts.linesBefore; i++) {
+		if (foundLineNo - i < 0) break;
+		const line = getLine(mark.buffer, lineStarts[foundLineNo - i], lineEnds[foundLineNo - i], mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]), maxLineLength);
+		result = `${" ".repeat(opts.indent)}${padStart((mark.line - i + 1).toString(), lineNoLength)} | ${line.str}\n${result}`;
+	}
+	const line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+	result += `${" ".repeat(opts.indent)}${padStart((mark.line + 1).toString(), lineNoLength)} | ${line.str}\n`;
+	result += `${"-".repeat(opts.indent + lineNoLength + 3 + line.pos)}^\n`;
+	for (let i = 1; i <= opts.linesAfter; i++) {
+		if (foundLineNo + i >= lineEnds.length) break;
+		const line = getLine(mark.buffer, lineStarts[foundLineNo + i], lineEnds[foundLineNo + i], mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]), maxLineLength);
+		result += `${" ".repeat(opts.indent)}${padStart((mark.line + i + 1).toString(), lineNoLength)} | ${line.str}\n`;
+	}
+	return result.replace(/\n$/, "");
+}
+//#endregion
+//#region src/common/exception.ts
+function formatError(exception, compact) {
+	let where = "";
+	if (!exception.mark) return exception.reason;
+	if (exception.mark.name) where += `in "${exception.mark.name}" `;
+	where += `(${exception.mark.line + 1}:${exception.mark.column + 1})`;
+	if (!compact && exception.mark.snippet) where += `\n\n${exception.mark.snippet}`;
+	return `${exception.reason} ${where}`;
+}
+var YAMLException = class extends Error {
+	constructor(reason, mark) {
+		super();
+		_defineProperty(this, "reason", void 0);
+		_defineProperty(this, "mark", void 0);
+		this.name = "YAMLException";
+		this.reason = reason;
+		this.mark = mark;
+		this.message = formatError(this, false);
+		if (Error.captureStackTrace) Error.captureStackTrace(this, this.constructor);
+	}
+	toString(compact) {
+		return `${this.name}: ${formatError(this, compact)}`;
+	}
+};
+function throwErrorAt(source, position, message, filename = "") {
+	let line = 0;
+	let lineStart = 0;
+	for (let index = 0; index < position; index++) {
+		const ch = source.charCodeAt(index);
+		if (ch === 10) {
+			line++;
+			lineStart = index + 1;
+		} else if (ch === 13) {
+			line++;
+			if (source.charCodeAt(index + 1) === 10) index++;
+			lineStart = index + 1;
+		}
+	}
+	const mark = {
+		name: filename,
+		buffer: source,
+		position,
+		line,
+		column: position - lineStart
+	};
+	mark.snippet = makeSnippet(mark);
+	throw new YAMLException(message, mark);
+}
+//#endregion
+//#region src/parser/events.ts
+var EVENT_DOCUMENT = 1;
+var EVENT_SEQUENCE = 2;
+var EVENT_MAPPING = 3;
+var EVENT_SCALAR = 4;
+var EVENT_ALIAS = 5;
+var EVENT_POP = 6;
+var SCALAR_STYLE_PLAIN = 1;
+var SCALAR_STYLE_SINGLE_QUOTED = 2;
+var SCALAR_STYLE_DOUBLE_QUOTED = 3;
+var SCALAR_STYLE_LITERAL_BLOCK = 4;
+var SCALAR_STYLE_FOLDED_BLOCK = 5;
+var COLLECTION_STYLE_BLOCK = 1;
+var COLLECTION_STYLE_FLOW = 2;
+var CHOMPING_CLIP = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP = 3;
+//#endregion
+//#region src/parser/parser_scalar.ts
+var NO_RANGE$3 = -1;
+function simpleEscapeSequence(c) {
+	switch (c) {
+		case 48: return "\0";
+		case 97: return "\x07";
+		case 98: return "\b";
+		case 116: return "	";
+		case 9: return "	";
+		case 110: return "\n";
+		case 118: return "\v";
+		case 102: return "\f";
+		case 114: return "\r";
+		case 101: return "\x1B";
+		case 32: return " ";
+		case 34: return "\"";
+		case 47: return "/";
+		case 92: return "\\";
+		case 78: return "";
+		case 95: return "\xA0";
+		case 76: return "\u2028";
+		case 80: return "\u2029";
+		default: return "";
+	}
+}
+var simpleEscapeCheck = new Array(256);
+var simpleEscapeMap = new Array(256);
+for (let i = 0; i < 256; i++) {
+	simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+	simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+function charFromCodepoint(c) {
+	if (c <= 65535) return String.fromCharCode(c);
+	return String.fromCharCode((c - 65536 >> 10) + 55296, (c - 65536 & 1023) + 56320);
+}
+function fromHexCode$1(c) {
+	if (c >= 48 && c <= 57) return c - 48;
+	return (c | 32) - 97 + 10;
+}
+function escapedHexLen$1(c) {
+	if (c === 120) return 2;
+	if (c === 117) return 4;
+	return 8;
+}
+function skipFoldedBreaks(input, position, end) {
+	let breaks = 0;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 10) {
+			breaks++;
+			position++;
+		} else if (ch === 13) {
+			breaks++;
+			position++;
+			if (input.charCodeAt(position) === 10) position++;
+		} else if (ch === 32 || ch === 9) position++;
+		else break;
+	}
+	return {
+		position,
+		breaks
+	};
+}
+function foldedBreaks(count) {
+	if (count === 1) return " ";
+	return "\n".repeat(count - 1);
+}
+function getPlainValue(input, start, end) {
+	let result = "";
+	let position = start;
+	let captureStart = start;
+	let captureEnd = start;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 10 || ch === 13) {
+			result += input.slice(captureStart, captureEnd);
+			const fold = skipFoldedBreaks(input, position, end);
+			result += foldedBreaks(fold.breaks);
+			position = captureStart = captureEnd = fold.position;
+		} else {
+			position++;
+			if (ch !== 32 && ch !== 9) captureEnd = position;
+		}
+	}
+	return result + input.slice(captureStart, captureEnd);
+}
+function getSingleQuotedValue(input, start, end) {
+	let result = "";
+	let position = start;
+	let captureStart = start;
+	let captureEnd = start;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 39) {
+			result += input.slice(captureStart, position) + "'";
+			position += 2;
+			captureStart = captureEnd = position;
+		} else if (ch === 10 || ch === 13) {
+			result += input.slice(captureStart, captureEnd);
+			const fold = skipFoldedBreaks(input, position, end);
+			result += foldedBreaks(fold.breaks);
+			position = captureStart = captureEnd = fold.position;
+		} else {
+			position++;
+			if (ch !== 32 && ch !== 9) captureEnd = position;
+		}
+	}
+	return result + input.slice(captureStart, end);
+}
+function getDoubleQuotedValue(input, start, end) {
+	let result = "";
+	let position = start;
+	let captureStart = start;
+	let captureEnd = start;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 92) {
+			result += input.slice(captureStart, position);
+			position++;
+			const escaped = input.charCodeAt(position);
+			if (escaped === 10 || escaped === 13) position = skipFoldedBreaks(input, position, end).position;
+			else if (escaped < 256 && simpleEscapeCheck[escaped]) {
+				result += simpleEscapeMap[escaped];
+				position++;
+			} else {
+				let hexLength = escapedHexLen$1(escaped);
+				let hexResult = 0;
+				for (; hexLength > 0; hexLength--) {
+					position++;
+					const digit = fromHexCode$1(input.charCodeAt(position));
+					hexResult = (hexResult << 4) + digit;
+				}
+				result += charFromCodepoint(hexResult);
+				position++;
+			}
+			captureStart = captureEnd = position;
+		} else if (ch === 10 || ch === 13) {
+			result += input.slice(captureStart, captureEnd);
+			const fold = skipFoldedBreaks(input, position, end);
+			result += foldedBreaks(fold.breaks);
+			position = captureStart = captureEnd = fold.position;
+		} else {
+			position++;
+			if (ch !== 32 && ch !== 9) captureEnd = position;
+		}
+	}
+	return result + input.slice(captureStart, end);
+}
+function getBlockValue(input, start, end, indent, chomping, folded) {
+	const textIndent = indent < 0 ? 0 : indent;
+	const region = input.slice(start, end).replace(/\r\n?/g, "\n");
+	const lines = region === "" ? [] : (region.endsWith("\n") ? region.slice(0, -1) : region).split("\n");
+	let result = "";
+	let didReadContent = false;
+	let emptyLines = 0;
+	let atMoreIndented = false;
+	for (const line of lines) {
+		let column = 0;
+		while (column < textIndent && line.charCodeAt(column) === 32) column++;
+		if (indent < 0 || column >= line.length) {
+			emptyLines++;
+			continue;
+		}
+		const content = line.slice(textIndent);
+		const first = content.charCodeAt(0);
+		if (folded) if (first === 32 || first === 9) {
+			atMoreIndented = true;
+			result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
+		} else if (atMoreIndented) {
+			atMoreIndented = false;
+			result += "\n".repeat(emptyLines + 1);
+		} else if (emptyLines === 0) {
+			if (didReadContent) result += " ";
+		} else result += "\n".repeat(emptyLines);
+		else result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
+		result += content;
+		didReadContent = true;
+		emptyLines = 0;
+	}
+	if (chomping === 3) result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
+	else if (chomping !== 2) {
+		if (didReadContent) result += "\n";
+	}
+	return result;
+}
+function getScalarValue(input, scalar) {
+	if (scalar.valueStart === NO_RANGE$3) return "";
+	const { valueStart, valueEnd } = scalar;
+	if (scalar.fast) return input.slice(valueStart, valueEnd);
+	switch (scalar.style) {
+		case 2: return getSingleQuotedValue(input, valueStart, valueEnd);
+		case 3: return getDoubleQuotedValue(input, valueStart, valueEnd);
+		case 4: return getBlockValue(input, valueStart, valueEnd, scalar.indent, scalar.chomping, false);
+		case 5: return getBlockValue(input, valueStart, valueEnd, scalar.indent, scalar.chomping, true);
+		default: return getPlainValue(input, valueStart, valueEnd);
+	}
+}
+//#endregion
+//#region src/common/tagname.ts
+var DEFAULT_TAG_HANDLERS = Object.assign(Object.create(null), {
+	"!": "!",
+	"!!": "tag:yaml.org,2002:"
+});
+function tagPercentEncode(source) {
+	return encodeURI(source).replace(/!/g, "%21");
+}
+function tagNameFull(rawTag, tagHandlers) {
+	var _ref, _tagHandlers$handle;
+	if (rawTag.startsWith("!<") && rawTag.endsWith(">")) return decodeURIComponent(rawTag.slice(2, -1));
+	const handleEnd = rawTag.indexOf("!", 1);
+	const handle = handleEnd === -1 ? "!" : rawTag.slice(0, handleEnd + 1);
+	const prefix = (_ref = (_tagHandlers$handle = tagHandlers === null || tagHandlers === void 0 ? void 0 : tagHandlers[handle]) !== null && _tagHandlers$handle !== void 0 ? _tagHandlers$handle : DEFAULT_TAG_HANDLERS[handle]) !== null && _ref !== void 0 ? _ref : handle;
+	return decodeURIComponent(prefix) + decodeURIComponent(rawTag.slice(handle.length));
+}
+function tagNameShort(fullTag) {
+	let tag = fullTag;
+	if (tag.charCodeAt(0) === 33) {
+		tag = tag.slice(1);
+		return `!${tagPercentEncode(tag)}`;
+	}
+	if (tag.slice(0, 18) === "tag:yaml.org,2002:") return `!!${tagPercentEncode(tag.slice(18))}`;
+	return `!<${tagPercentEncode(tag)}>`;
+}
+//#endregion
+//#region src/parser/constructor.ts
+var NO_RANGE$2 = -1;
+var DEFAULT_CONSTRUCTOR_OPTIONS = {
+	filename: "",
+	schema: CORE_SCHEMA,
+	json: false,
+	maxTotalMergeKeys: 1e4,
+	maxAliases: -1
+};
+function eventPosition$1(event) {
+	if ("tagStart" in event && event.tagStart !== NO_RANGE$2) return event.tagStart;
+	if ("anchorStart" in event && event.anchorStart !== NO_RANGE$2) return event.anchorStart;
+	if ("valueStart" in event && event.valueStart !== NO_RANGE$2) return event.valueStart;
+	if ("start" in event) return event.start;
+	return 0;
+}
+function throwError$1(state, message) {
+	throwErrorAt(state.source, state.position, message, state.filename);
+}
+function finalizeCollection(state, position, tag, carrier) {
+	try {
+		return tag.finalize(carrier);
+	} catch (error) {
+		if (error instanceof YAMLException) throw error;
+		throwErrorAt(state.source, position, error instanceof Error ? error.message : String(error), state.filename);
+	}
+}
+function lookupTag(exact, prefix, tagName) {
+	const exactTag = exact[tagName];
+	if (exactTag) return exactTag;
+	for (const tag of prefix) if (tagName.startsWith(tag.tagName)) return tag;
+}
+function findExplicitTag(state, exact, prefix, tagName, nodeKind) {
+	const tag = lookupTag(exact, prefix, tagName);
+	if (tag) return tag;
+	throwError$1(state, `unknown ${nodeKind} tag !<${tagName}>`);
+}
+function constructScalar(state, event) {
+	const source = getScalarValue(state.source, event);
+	const rawTag = event.tagStart === NO_RANGE$2 ? "" : state.source.slice(event.tagStart, event.tagEnd);
+	const strTag = state.schema.defaultScalarTag;
+	if (rawTag !== "") {
+		var _lookupTag;
+		if (rawTag === "!") return {
+			value: source,
+			tag: strTag
+		};
+		const tagName = tagNameFull(rawTag, state.tagHandlers);
+		const scalarTag = lookupTag(state.schema.exact.scalar, state.schema.prefix.scalar, tagName);
+		if (scalarTag) {
+			const result = scalarTag.resolve(source, true, tagName);
+			if (result === NOT_RESOLVED) throwError$1(state, `cannot resolve a node with !<${tagName}> explicit tag`);
+			return {
+				value: result,
+				tag: scalarTag
+			};
+		}
+		const collectionTagDef = (_lookupTag = lookupTag(state.schema.exact.mapping, state.schema.prefix.mapping, tagName)) !== null && _lookupTag !== void 0 ? _lookupTag : lookupTag(state.schema.exact.sequence, state.schema.prefix.sequence, tagName);
+		if (collectionTagDef) {
+			if (source !== "") throwError$1(state, `cannot resolve a node with !<${tagName}> explicit tag`);
+			const carrier = collectionTagDef.create(tagName);
+			return {
+				value: collectionTagDef.carrierIsResult ? carrier : finalizeCollection(state, state.position, collectionTagDef, carrier),
+				tag: collectionTagDef
+			};
+		}
+		throwError$1(state, `unknown scalar tag !<${tagName}>`);
+	}
+	if (event.style === 1) {
+		var _state$schema$implici;
+		const candidates = (_state$schema$implici = state.schema.implicitScalarByFirstChar.get(source.charAt(0))) !== null && _state$schema$implici !== void 0 ? _state$schema$implici : state.schema.implicitScalarAnyFirstChar;
+		for (const tag of candidates) {
+			const result = tag.resolve(source, false, tag.tagName);
+			if (result !== NOT_RESOLVED) return {
+				value: result,
+				tag
+			};
+		}
+	}
+	return {
+		value: strTag.resolve(source, false, strTag.tagName),
+		tag: strTag
+	};
+}
+function collectionTag(state, event, exact, prefix, defaultTagName, nodeKind) {
+	const rawTag = event.tagStart === NO_RANGE$2 ? "" : state.source.slice(event.tagStart, event.tagEnd);
+	const tagName = rawTag === "" || rawTag === "!" ? defaultTagName : tagNameFull(rawTag, state.tagHandlers);
+	return {
+		tagName,
+		tag: findExplicitTag(state, exact, prefix, tagName, nodeKind)
+	};
+}
+function isMappingTag(tag) {
+	return tag.nodeKind === "mapping";
+}
+function mergeKeys(state, frame, source, sourceTag) {
+	for (const sourceKey of sourceTag.keys(source)) {
+		var _frame$overridable;
+		if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) throwError$1(state, `merge keys exceeded maxTotalMergeKeys (${state.maxTotalMergeKeys})`);
+		if (frame.tag.has(frame.value, sourceKey)) continue;
+		const err = frame.tag.addPair(frame.value, sourceKey, sourceTag.get(source, sourceKey));
+		if (err) throwError$1(state, err);
+		((_frame$overridable = frame.overridable) !== null && _frame$overridable !== void 0 ? _frame$overridable : frame.overridable = /* @__PURE__ */ new Set()).add(sourceKey);
+	}
+}
+function mergeSource(state, frame, source, sourceTag) {
+	state.position = frame.keyPosition;
+	if (isMappingTag(sourceTag)) mergeKeys(state, frame, source, sourceTag);
+	else if (sourceTag.nodeKind === "sequence" && Array.isArray(source)) for (const element of source) mergeKeys(state, frame, element, frame.tag);
+	else throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+}
+function addMappingValue(state, frame, key, value, tag) {
+	var _frame$overridable2, _frame$overridable3;
+	state.position = frame.keyPosition;
+	if (key === MERGE_KEY) {
+		mergeSource(state, frame, value, tag);
+		return;
+	}
+	if (!state.json && frame.tag.has(frame.value, key) && !((_frame$overridable2 = frame.overridable) === null || _frame$overridable2 === void 0 ? void 0 : _frame$overridable2.has(key))) throwError$1(state, "duplicated mapping key");
+	const err = frame.tag.addPair(frame.value, key, value);
+	if (err) throwError$1(state, err);
+	(_frame$overridable3 = frame.overridable) === null || _frame$overridable3 === void 0 || _frame$overridable3.delete(key);
+}
+function addValue(state, value, tag) {
+	const frame = state.frames[state.frames.length - 1];
+	if (frame.kind === "document") {
+		frame.value = value;
+		frame.hasValue = true;
+	} else if (frame.kind === "sequence") {
+		if (frame.merge) {
+			if (!isMappingTag(tag)) throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+		}
+		const err = frame.tag.addItem(frame.value, value, frame.index++);
+		if (err) throwError$1(state, err);
+	} else if (frame.hasKey) {
+		const key = frame.key;
+		frame.key = void 0;
+		frame.hasKey = false;
+		addMappingValue(state, frame, key, value, tag);
+	} else {
+		frame.key = value;
+		frame.keyPosition = state.position;
+		frame.hasKey = true;
+	}
+}
+function storeAnchor(state, event, value, tag, isValueFinal) {
+	if (event.anchorStart !== NO_RANGE$2) {
+		const anchor = {
+			value,
+			tag,
+			isValueFinal
+		};
+		state.anchors.set(state.source.slice(event.anchorStart, event.anchorEnd), anchor);
+		return anchor;
+	}
+	return null;
+}
+function constructFromEvents(events, options) {
+	const state = _objectSpread2(_objectSpread2(_objectSpread2({}, DEFAULT_CONSTRUCTOR_OPTIONS), options), {}, {
+		events,
+		documents: [],
+		eventIndex: 0,
+		position: 0,
+		frames: [],
+		anchors: /* @__PURE__ */ new Map(),
+		tagHandlers: Object.create(null),
+		totalMergeKeys: 0,
+		aliasCount: 0
+	});
+	while (state.eventIndex < state.events.length) {
+		const event = state.events[state.eventIndex++];
+		state.position = eventPosition$1(event);
+		switch (event.type) {
+			case 1:
+				state.anchors = /* @__PURE__ */ new Map();
+				state.aliasCount = 0;
+				state.tagHandlers = Object.create(null);
+				for (const directive of event.directives) if (directive.kind === "tag") state.tagHandlers[directive.handle] = directive.prefix;
+				state.frames.push({
+					kind: "document",
+					position: state.position,
+					value: void 0,
+					hasValue: false
+				});
+				break;
+			case 4: {
+				const { value, tag } = constructScalar(state, event);
+				storeAnchor(state, event, value, tag, true);
+				addValue(state, value, tag);
+				break;
+			}
+			case 2: {
+				const definition = collectionTag(state, event, state.schema.exact.sequence, state.schema.prefix.sequence, "tag:yaml.org,2002:seq", "sequence");
+				const value = definition.tag.create(definition.tagName);
+				const anchor = storeAnchor(state, event, value, definition.tag, definition.tag.carrierIsResult);
+				const parent = state.frames[state.frames.length - 1];
+				const merge = parent !== void 0 && parent.kind === "mapping" && parent.hasKey && parent.key === MERGE_KEY;
+				state.frames.push({
+					kind: "sequence",
+					position: state.position,
+					value,
+					tag: definition.tag,
+					anchor,
+					index: 0,
+					merge
+				});
+				break;
+			}
+			case 3: {
+				const definition = collectionTag(state, event, state.schema.exact.mapping, state.schema.prefix.mapping, "tag:yaml.org,2002:map", "mapping");
+				const value = definition.tag.create(definition.tagName);
+				const anchor = storeAnchor(state, event, value, definition.tag, definition.tag.carrierIsResult);
+				state.frames.push({
+					kind: "mapping",
+					position: state.position,
+					value,
+					tag: definition.tag,
+					anchor,
+					key: void 0,
+					keyPosition: state.position,
+					hasKey: false,
+					overridable: null
+				});
+				break;
+			}
+			case 5: {
+				if (state.maxAliases !== -1 && ++state.aliasCount > state.maxAliases) throwError$1(state, `aliases exceeded maxAliases (${state.maxAliases})`);
+				const name = state.source.slice(event.anchorStart, event.anchorEnd);
+				const anchor = state.anchors.get(name);
+				if (!anchor) throwError$1(state, `unidentified alias "${name}"`);
+				if (!anchor.isValueFinal) throwError$1(state, `recursive alias "${name}" is not supported for tag ${anchor.tag.tagName} because it uses finalize()`);
+				addValue(state, anchor.value, anchor.tag);
+				break;
+			}
+			case 6: {
+				const frame = state.frames.pop();
+				if (frame.kind === "mapping" && frame.hasKey) {
+					state.position = frame.keyPosition;
+					throwError$1(state, "incomplete mapping pair in event stream");
+				}
+				if (frame.kind === "document") state.documents.push(frame.value);
+				else {
+					const value = frame.tag.carrierIsResult ? frame.value : finalizeCollection(state, frame.position, frame.tag, frame.value);
+					if (frame.anchor) {
+						frame.anchor.value = value;
+						frame.anchor.isValueFinal = true;
+					}
+					addValue(state, value, frame.tag);
+				}
+				break;
+			}
+		}
+	}
+	return state.documents;
+}
+//#endregion
+//#region src/parser/parser.ts
+var NO_RANGE$1 = -1;
+var HAS_OWN = Object.prototype.hasOwnProperty;
+var CONTEXT_FLOW_IN = 1;
+var CONTEXT_FLOW_OUT = 2;
+var CONTEXT_BLOCK_IN = 3;
+var CONTEXT_BLOCK_OUT = 4;
+var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+var PATTERN_FLOW_INDICATORS = /[,\[\]{}]/;
+var PATTERN_TAG_HANDLE = /^(?:!|!!|![0-9A-Za-z-]+!)$/;
+var NS_URI_CHAR = String.raw`(?:%[0-9A-Fa-f]{2}|[0-9A-Za-z\-#;/?:@&=+$,_.!~*'()\[\]])`;
+var NS_TAG_CHAR = String.raw`(?:%[0-9A-Fa-f]{2}|[0-9A-Za-z\-#;/?:@&=+$.~*'()_])`;
+var PATTERN_TAG_URI = new RegExp(`^(?:${NS_URI_CHAR})*$`);
+var PATTERN_TAG_SUFFIX = new RegExp(`^(?:${NS_TAG_CHAR})+$`);
+var PATTERN_TAG_PREFIX = new RegExp(`^(?:!(?:${NS_URI_CHAR})*|${NS_TAG_CHAR}(?:${NS_URI_CHAR})*)$`);
+var DEFAULT_PARSER_OPTIONS = {
+	filename: "",
+	maxDepth: 100
+};
+function addDocumentEvent(state, explicitStart, explicitEnd) {
+	state.events.push({
+		type: 1,
+		explicitStart,
+		explicitEnd,
+		directives: state.directives
+	});
+}
+function addSequenceEvent(state, start, anchorStart, anchorEnd, tagStart, tagEnd, style) {
+	state.events.push({
+		type: 2,
+		start,
+		anchorStart,
+		anchorEnd,
+		tagStart,
+		tagEnd,
+		style
+	});
+}
+function addMappingEvent(state, start, anchorStart, anchorEnd, tagStart, tagEnd, style) {
+	state.events.push({
+		type: 3,
+		start,
+		anchorStart,
+		anchorEnd,
+		tagStart,
+		tagEnd,
+		style
+	});
+}
+function insertFlowPairMappingEvent(state, snapshot) {
+	state.events.splice(snapshot.eventsLength, 0, {
+		type: 3,
+		start: snapshot.position,
+		anchorStart: NO_RANGE$1,
+		anchorEnd: NO_RANGE$1,
+		tagStart: NO_RANGE$1,
+		tagEnd: NO_RANGE$1,
+		style: 2
+	});
+}
+function addScalarEvent(state, valueStart, valueEnd, anchorStart, anchorEnd, tagStart, tagEnd, style, chomping = 1, indent = -1, fast = false) {
+	state.events.push({
+		type: 4,
+		valueStart,
+		valueEnd,
+		anchorStart,
+		anchorEnd,
+		tagStart,
+		tagEnd,
+		style,
+		chomping,
+		indent,
+		fast
+	});
+}
+function addAliasEvent(state, anchorStart, anchorEnd) {
+	state.events.push({
+		type: 5,
+		anchorStart,
+		anchorEnd
+	});
+}
+function addPopEvent(state) {
+	state.events.push({ type: 6 });
+}
+function addEmptyScalarEvent(state) {
+	addScalarEvent(state, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, 1);
+}
+function emptyProperties() {
+	return {
+		anchorStart: NO_RANGE$1,
+		anchorEnd: NO_RANGE$1,
+		tagStart: NO_RANGE$1,
+		tagEnd: NO_RANGE$1
+	};
+}
+function snapshotState(state) {
+	return {
+		position: state.position,
+		line: state.line,
+		lineStart: state.lineStart,
+		lineIndent: state.lineIndent,
+		firstTabInLine: state.firstTabInLine,
+		eventsLength: state.events.length
+	};
+}
+function restoreState(state, snapshot) {
+	state.position = snapshot.position;
+	state.line = snapshot.line;
+	state.lineStart = snapshot.lineStart;
+	state.lineIndent = snapshot.lineIndent;
+	state.firstTabInLine = snapshot.firstTabInLine;
+	state.events.length = snapshot.eventsLength;
+}
+function throwError(state, message) {
+	throwErrorAt(state.input.slice(0, state.length), state.position, message, state.filename);
+}
+function isEol(c) {
+	return c === 10 || c === 13;
+}
+function isWhiteSpace(c) {
+	return c === 9 || c === 32;
+}
+function isWsOrEol(c) {
+	return isWhiteSpace(c) || isEol(c);
+}
+function isWsOrEolOrEnd(c) {
+	return c === 0 || isWsOrEol(c);
+}
+function isFlowIndicator(c) {
+	return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
+}
+function fromDecimalCode(c) {
+	return c >= 48 && c <= 57 ? c - 48 : -1;
+}
+function fromHexCode(c) {
+	if (c >= 48 && c <= 57) return c - 48;
+	const lc = c | 32;
+	if (lc >= 97 && lc <= 102) return lc - 97 + 10;
+	return -1;
+}
+function escapedHexLen(c) {
+	if (c === 120) return 2;
+	if (c === 117) return 4;
+	if (c === 85) return 8;
+	return 0;
+}
+function isSimpleEscape(c) {
+	return c === 48 || c === 97 || c === 98 || c === 116 || c === 9 || c === 110 || c === 118 || c === 102 || c === 114 || c === 101 || c === 32 || c === 34 || c === 47 || c === 92 || c === 78 || c === 95 || c === 76 || c === 80;
+}
+function consumeLineBreak(state) {
+	if (state.input.charCodeAt(state.position) === 10) state.position++;
+	else {
+		state.position++;
+		if (state.input.charCodeAt(state.position) === 10) state.position++;
+	}
+	state.line++;
+	state.lineStart = state.position;
+	state.lineIndent = 0;
+	state.firstTabInLine = -1;
+}
+function skipSeparationSpace(state, allowComments) {
+	let lineBreaks = 0;
+	let ch = state.input.charCodeAt(state.position);
+	let hasSeparation = state.position === state.lineStart || isWsOrEol(state.input.charCodeAt(state.position - 1));
+	while (ch !== 0) {
+		while (isWhiteSpace(ch)) {
+			hasSeparation = true;
+			if (ch === 9 && state.firstTabInLine === -1) state.firstTabInLine = state.position;
+			ch = state.input.charCodeAt(++state.position);
+		}
+		if (allowComments && hasSeparation && ch === 35) do
+			ch = state.input.charCodeAt(++state.position);
+		while (!isEol(ch) && ch !== 0);
+		if (!isEol(ch)) break;
+		consumeLineBreak(state);
+		lineBreaks++;
+		hasSeparation = true;
+		ch = state.input.charCodeAt(state.position);
+		while (ch === 32) {
+			state.lineIndent++;
+			ch = state.input.charCodeAt(++state.position);
+		}
+	}
+	return lineBreaks;
+}
+function testDocumentSeparator(state, position = state.position) {
+	const ch = state.input.charCodeAt(position);
+	if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(position + 1) && ch === state.input.charCodeAt(position + 2)) {
+		const following = state.input.charCodeAt(position + 3);
+		return following === 0 || isWsOrEol(following);
+	}
+	return false;
+}
+function skipUntilLineEnd(state) {
+	let ch = state.input.charCodeAt(state.position);
+	while (ch !== 0 && !isEol(ch)) ch = state.input.charCodeAt(++state.position);
+}
+function checkPrintable(state, start, end) {
+	if (PATTERN_NON_PRINTABLE.test(state.input.slice(start, end))) throwError(state, "the stream contains non-printable characters");
+}
+function readTagProperty(state, props, inFlow) {
+	if (state.input.charCodeAt(state.position) !== 33) return false;
+	if (props.tagStart !== NO_RANGE$1) throwError(state, "duplication of a tag property");
+	const start = state.position;
+	let isVerbatim = false;
+	let isNamed = false;
+	let tagHandle = "!";
+	let ch = state.input.charCodeAt(++state.position);
+	if (ch === 60) {
+		isVerbatim = true;
+		ch = state.input.charCodeAt(++state.position);
+	} else if (ch === 33) {
+		isNamed = true;
+		tagHandle = "!!";
+		ch = state.input.charCodeAt(++state.position);
+	}
+	let suffixStart = state.position;
+	let tagName;
+	if (isVerbatim) {
+		while (ch !== 0 && ch !== 62) ch = state.input.charCodeAt(++state.position);
+		if (ch !== 62) throwError(state, "unexpected end of the stream within a verbatim tag");
+		tagName = state.input.slice(suffixStart, state.position);
+		state.position++;
+	} else {
+		while (ch !== 0 && !isWsOrEol(ch) && !(inFlow && isFlowIndicator(ch))) {
+			if (ch === 33) if (!isNamed) {
+				tagHandle = state.input.slice(suffixStart - 1, state.position + 1);
+				if (!PATTERN_TAG_HANDLE.test(tagHandle)) throwError(state, "named tag handle cannot contain such characters");
+				isNamed = true;
+				suffixStart = state.position + 1;
+			} else throwError(state, "tag suffix cannot contain exclamation marks");
+			ch = state.input.charCodeAt(++state.position);
+		}
+		tagName = state.input.slice(suffixStart, state.position);
+		if (PATTERN_FLOW_INDICATORS.test(tagName)) throwError(state, "tag suffix cannot contain flow indicator characters");
+	}
+	if (tagName && !(isVerbatim ? PATTERN_TAG_URI.test(tagName) : PATTERN_TAG_SUFFIX.test(tagName))) throwError(state, `tag name cannot contain such characters: ${tagName}`);
+	if (!isVerbatim && tagHandle !== "!" && tagHandle !== "!!" && !HAS_OWN.call(state.tagHandlers, tagHandle)) throwError(state, `undeclared tag handle "${tagHandle}"`);
+	props.tagStart = start;
+	props.tagEnd = state.position;
+	return true;
+}
+function readAnchorProperty(state, props) {
+	if (state.input.charCodeAt(state.position) !== 38) return false;
+	if (props.anchorStart !== NO_RANGE$1) throwError(state, "duplication of an anchor property");
+	state.position++;
+	const start = state.position;
+	while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position)) && !isFlowIndicator(state.input.charCodeAt(state.position))) state.position++;
+	if (state.position === start) throwError(state, "name of an anchor node must contain at least one character");
+	props.anchorStart = start;
+	props.anchorEnd = state.position;
+	return true;
+}
+function readAlias(state, props) {
+	if (state.input.charCodeAt(state.position) !== 42) return false;
+	if (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1) throwError(state, "alias node should not have any properties");
+	state.position++;
+	const start = state.position;
+	while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position)) && !isFlowIndicator(state.input.charCodeAt(state.position))) state.position++;
+	if (state.position === start) throwError(state, "name of an alias node must contain at least one character");
+	addAliasEvent(state, start, state.position);
+	return true;
+}
+function readFlowScalarBreak(state, nodeIndent) {
+	skipSeparationSpace(state, false);
+	if (state.lineIndent < nodeIndent) throwError(state, "deficient indentation");
+}
+function readSingleQuotedScalar(state, nodeIndent, props) {
+	if (state.input.charCodeAt(state.position) !== 39) return false;
+	state.position++;
+	const start = state.position;
+	let simple = true;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const ch = state.input.charCodeAt(state.position);
+		if (ch === 39) {
+			if (state.input.charCodeAt(state.position + 1) === 39) {
+				simple = false;
+				state.position += 2;
+				continue;
+			}
+			const end = state.position;
+			state.position++;
+			addScalarEvent(state, start, end, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 2, 1, -1, simple);
+			return true;
+		}
+		if (isEol(ch)) {
+			simple = false;
+			readFlowScalarBreak(state, nodeIndent);
+		} else if (state.position === state.lineStart && testDocumentSeparator(state)) throwError(state, "unexpected end of the document within a single quoted scalar");
+		else if (ch !== 9 && ch < 32) throwError(state, "expected valid JSON character");
+		else state.position++;
+	}
+	throwError(state, "unexpected end of the stream within a single quoted scalar");
+}
+function readDoubleQuotedScalar(state, nodeIndent, props) {
+	if (state.input.charCodeAt(state.position) !== 34) return false;
+	state.position++;
+	const start = state.position;
+	let simple = true;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const ch = state.input.charCodeAt(state.position);
+		if (ch === 34) {
+			const end = state.position;
+			state.position++;
+			addScalarEvent(state, start, end, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 3, 1, -1, simple);
+			return true;
+		}
+		if (ch === 92) {
+			simple = false;
+			const escaped = state.input.charCodeAt(++state.position);
+			if (isEol(escaped)) readFlowScalarBreak(state, nodeIndent);
+			else if (isSimpleEscape(escaped)) state.position++;
+			else {
+				let hexLength = escapedHexLen(escaped);
+				if (hexLength === 0) throwError(state, "unknown escape sequence");
+				while (hexLength-- > 0) {
+					state.position++;
+					if (fromHexCode(state.input.charCodeAt(state.position)) < 0) throwError(state, "expected hexadecimal character");
+				}
+				state.position++;
+			}
+		} else if (isEol(ch)) {
+			simple = false;
+			readFlowScalarBreak(state, nodeIndent);
+		} else if (state.position === state.lineStart && testDocumentSeparator(state)) throwError(state, "unexpected end of the document within a double quoted scalar");
+		else if (ch !== 9 && ch < 32) throwError(state, "expected valid JSON character");
+		else state.position++;
+	}
+	throwError(state, "unexpected end of the stream within a double quoted scalar");
+}
+function readBlockScalar(state, parentIndent, props) {
+	const ch = state.input.charCodeAt(state.position);
+	let chomping = 1;
+	let indent = -1;
+	let detectedIndent = false;
+	if (ch !== 124 && ch !== 62) return false;
+	const style = ch === 124 ? 4 : 5;
+	state.position++;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const current = state.input.charCodeAt(state.position);
+		const digit = fromDecimalCode(current);
+		if (current === 43 || current === 45) {
+			if (chomping !== 1) throwError(state, "repeat of a chomping mode identifier");
+			chomping = current === 43 ? 3 : 2;
+			state.position++;
+		} else if (digit >= 0) {
+			if (digit === 0) throwError(state, "bad explicit indentation width of a block scalar; it cannot be less than one");
+			if (detectedIndent) throwError(state, "repeat of an indentation width identifier");
+			indent = parentIndent + digit - 1;
+			detectedIndent = true;
+			state.position++;
+		} else break;
+	}
+	let hadWhitespace = false;
+	while (isWhiteSpace(state.input.charCodeAt(state.position))) {
+		hadWhitespace = true;
+		state.position++;
+	}
+	if (hadWhitespace && state.input.charCodeAt(state.position) === 35) skipUntilLineEnd(state);
+	if (isEol(state.input.charCodeAt(state.position))) consumeLineBreak(state);
+	else if (state.input.charCodeAt(state.position) !== 0) throwError(state, "a line break is expected");
+	let contentIndent = detectedIndent ? indent : -1;
+	let maxLeadingIndent = 0;
+	const valueStart = state.position;
+	let valueEnd = state.position;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const linePosition = state.position;
+		let column = 0;
+		while (state.input.charCodeAt(linePosition + column) === 32) column++;
+		const first = state.input.charCodeAt(linePosition + column);
+		if (first === 0) {
+			if (contentIndent >= 0) {
+				if (column > contentIndent) valueEnd = linePosition + column;
+			} else if (column > 0) valueEnd = linePosition + column;
+			break;
+		}
+		if (linePosition === state.lineStart && testDocumentSeparator(state, linePosition)) break;
+		if (!detectedIndent && contentIndent === -1 && isEol(first)) maxLeadingIndent = Math.max(maxLeadingIndent, column);
+		if (!detectedIndent && contentIndent === -1 && !isEol(first)) {
+			if (first === 9 && column < parentIndent) {
+				state.position = linePosition + column;
+				throwError(state, "tab characters must not be used in indentation");
+			}
+			if (column < maxLeadingIndent) {
+				state.position = linePosition + column;
+				throwError(state, "bad indentation of a mapping entry");
+			}
+		}
+		if (contentIndent === -1 && first !== 0 && !isEol(first) && column < parentIndent) {
+			state.lineIndent = column;
+			state.position = linePosition + column;
+			break;
+		}
+		if (!detectedIndent && first !== 0 && !isEol(first) && contentIndent === -1) contentIndent = column;
+		const requiredIndent = contentIndent === -1 ? parentIndent + 1 : contentIndent;
+		if (first !== 0 && !isEol(first) && column < requiredIndent) {
+			state.lineIndent = column;
+			state.position = linePosition + column;
+			break;
+		}
+		skipUntilLineEnd(state);
+		valueEnd = state.position;
+		if (isEol(state.input.charCodeAt(state.position))) {
+			consumeLineBreak(state);
+			valueEnd = state.position;
+		}
+	}
+	checkPrintable(state, valueStart, valueEnd);
+	addScalarEvent(state, valueStart, valueEnd, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, style, chomping, contentIndent);
+	return true;
+}
+function canStartPlainScalar(state, nodeContext) {
+	const ch = state.input.charCodeAt(state.position);
+	const inFlow = nodeContext === CONTEXT_FLOW_IN;
+	if (ch === 0 || isWsOrEol(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96 || inFlow && isFlowIndicator(ch)) return false;
+	if (ch === 63 || ch === 45) {
+		const following = state.input.charCodeAt(state.position + 1);
+		if (isWsOrEolOrEnd(following) || inFlow && isFlowIndicator(following)) return false;
+	}
+	return true;
+}
+function readPlainScalar(state, nodeIndent, nodeContext, props) {
+	if (!canStartPlainScalar(state, nodeContext)) return false;
+	const start = state.position;
+	let end = state.position;
+	let ch = state.input.charCodeAt(state.position);
+	const inFlow = nodeContext === CONTEXT_FLOW_IN;
+	let multiline = false;
+	while (ch !== 0) {
+		if (state.position === state.lineStart && testDocumentSeparator(state)) break;
+		if (ch === 58) {
+			const following = state.input.charCodeAt(state.position + 1);
+			if (isWsOrEolOrEnd(following) || inFlow && isFlowIndicator(following)) break;
+		} else if (ch === 35) {
+			if (isWsOrEol(state.input.charCodeAt(state.position - 1))) break;
+		} else if (inFlow && isFlowIndicator(ch)) break;
+		else if (isEol(ch)) {
+			const savedPosition = state.position;
+			const savedLine = state.line;
+			const savedLineStart = state.lineStart;
+			const savedLineIndent = state.lineIndent;
+			skipSeparationSpace(state, false);
+			if (state.lineIndent >= nodeIndent) {
+				multiline = true;
+				ch = state.input.charCodeAt(state.position);
+				continue;
+			}
+			state.position = savedPosition;
+			state.line = savedLine;
+			state.lineStart = savedLineStart;
+			state.lineIndent = savedLineIndent;
+			break;
+		}
+		if (!isWhiteSpace(ch)) end = state.position + 1;
+		ch = state.input.charCodeAt(++state.position);
+	}
+	if (end === start) return false;
+	checkPrintable(state, start, end);
+	addScalarEvent(state, start, end, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1, 1, -1, !multiline);
+	return true;
+}
+function skipFlowSeparationSpace(state, nodeIndent) {
+	const startLine = state.line;
+	skipSeparationSpace(state, true);
+	if (state.line > startLine && state.lineIndent < nodeIndent || state.firstTabInLine !== -1 && state.lineIndent < nodeIndent) throwError(state, "deficient indentation");
+}
+function readFlowCollection(state, nodeIndent, props) {
+	const ch = state.input.charCodeAt(state.position);
+	const isMapping = ch === 123;
+	const start = state.position;
+	let readNext = true;
+	if (ch !== 91 && ch !== 123) return false;
+	const terminator = isMapping ? 125 : 93;
+	if (isMapping) addMappingEvent(state, start, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 2);
+	else addSequenceEvent(state, start, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 2);
+	state.position++;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		skipFlowSeparationSpace(state, nodeIndent);
+		let ch = state.input.charCodeAt(state.position);
+		if (ch === terminator) {
+			state.position++;
+			addPopEvent(state);
+			return true;
+		} else if (!readNext) throwError(state, "missed comma between flow collection entries");
+		else if (ch === 44) throwError(state, "expected the node content, but found ','");
+		let isPair = false;
+		let isExplicitPair = false;
+		if (ch === 63 && isWsOrEol(state.input.charCodeAt(state.position + 1))) {
+			isPair = isExplicitPair = true;
+			state.position += 1;
+			skipFlowSeparationSpace(state, nodeIndent);
+		}
+		const entryLine = state.line;
+		const entryStart = snapshotState(state);
+		const keyWasRead = parseNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+		skipFlowSeparationSpace(state, nodeIndent);
+		ch = state.input.charCodeAt(state.position);
+		if ((isMapping || isExplicitPair || state.line === entryLine) && ch === 58) {
+			isPair = true;
+			state.position++;
+			skipFlowSeparationSpace(state, nodeIndent);
+			if (!isMapping) {
+				insertFlowPairMappingEvent(state, entryStart);
+				if (!keyWasRead) addEmptyScalarEvent(state);
+			} else if (!keyWasRead) addEmptyScalarEvent(state);
+			if (!parseNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true)) addEmptyScalarEvent(state);
+			skipFlowSeparationSpace(state, nodeIndent);
+			if (!isMapping) addPopEvent(state);
+		} else if (isMapping && isPair) {
+			if (!keyWasRead) addEmptyScalarEvent(state);
+			addEmptyScalarEvent(state);
+		} else if (isMapping) addEmptyScalarEvent(state);
+		else if (isPair) {
+			insertFlowPairMappingEvent(state, entryStart);
+			if (!keyWasRead) addEmptyScalarEvent(state);
+			addEmptyScalarEvent(state);
+			addPopEvent(state);
+		}
+		ch = state.input.charCodeAt(state.position);
+		if (ch === 44) {
+			readNext = true;
+			state.position++;
+		} else readNext = false;
+	}
+	throwError(state, "unexpected end of the stream within a flow collection");
+}
+function readBlockSequence(state, nodeIndent, props) {
+	if (state.firstTabInLine !== -1 || state.input.charCodeAt(state.position) !== 45 || !isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) return false;
+	addSequenceEvent(state, state.position, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+	while (state.input.charCodeAt(state.position) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) {
+		if (state.firstTabInLine !== -1) {
+			state.position = state.firstTabInLine;
+			throwError(state, "tab characters must not be used in indentation");
+		}
+		const entryLine = state.line;
+		state.position++;
+		const hadBreak = skipSeparationSpace(state, true) > 0;
+		if (state.firstTabInLine !== -1 && state.input.charCodeAt(state.position) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) throwError(state, "bad indentation of a sequence entry");
+		if (hadBreak && state.lineIndent <= nodeIndent) addEmptyScalarEvent(state);
+		else parseNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+		skipSeparationSpace(state, true);
+		if (state.lineIndent < nodeIndent || state.position >= state.length) break;
+		if (state.lineIndent > nodeIndent) throwError(state, "bad indentation of a sequence entry");
+		if (state.line === entryLine && state.input.charCodeAt(state.position) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) throwError(state, "bad indentation of a sequence entry");
+	}
+	addPopEvent(state);
+	return true;
+}
+function readBlockMapping(state, nodeIndent, flowIndent, props) {
+	let atExplicitKey = false;
+	let detected = false;
+	let mappingOpened = false;
+	let pendingExplicitKey = false;
+	if (state.firstTabInLine !== -1) return false;
+	let ch = state.input.charCodeAt(state.position);
+	while (ch !== 0) {
+		if (!atExplicitKey && state.firstTabInLine !== -1) {
+			state.position = state.firstTabInLine;
+			throwError(state, "tab characters must not be used in indentation");
+		}
+		const following = state.input.charCodeAt(state.position + 1);
+		const entryLine = state.line;
+		if ((ch === 63 || ch === 58) && isWsOrEolOrEnd(following)) {
+			if (!mappingOpened) {
+				addMappingEvent(state, state.position, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+				mappingOpened = true;
+			}
+			if (ch === 63) {
+				if (atExplicitKey) addEmptyScalarEvent(state);
+				detected = true;
+				atExplicitKey = true;
+			} else if (atExplicitKey) atExplicitKey = false;
+			else {
+				addEmptyScalarEvent(state);
+				detected = true;
+				atExplicitKey = false;
+			}
+			state.position += 1;
+			pendingExplicitKey = true;
+		} else {
+			if (atExplicitKey) {
+				addEmptyScalarEvent(state);
+				atExplicitKey = false;
+			}
+			const beforeKey = snapshotState(state);
+			if (!parseNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) break;
+			if (state.line === entryLine) {
+				ch = state.input.charCodeAt(state.position);
+				while (isWhiteSpace(ch)) ch = state.input.charCodeAt(++state.position);
+				if (ch === 58) {
+					ch = state.input.charCodeAt(++state.position);
+					if (!isWsOrEolOrEnd(ch)) throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
+					if (!mappingOpened) {
+						restoreState(state, beforeKey);
+						addMappingEvent(state, beforeKey.position, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+						mappingOpened = true;
+						parseNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true);
+						ch = state.input.charCodeAt(state.position);
+						while (isWhiteSpace(ch)) ch = state.input.charCodeAt(++state.position);
+						state.position++;
+					}
+					detected = true;
+					atExplicitKey = false;
+					pendingExplicitKey = false;
+				} else if (detected) throwError(state, "expected ':' after a mapping key");
+				else {
+					if (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1) {
+						restoreState(state, beforeKey);
+						return false;
+					}
+					return true;
+				}
+			} else if (detected) throwError(state, "can not read a block mapping entry; a multiline key may not be an implicit key");
+			else {
+				if (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1) {
+					restoreState(state, beforeKey);
+					return false;
+				}
+				return true;
+			}
+		}
+		if (parseNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, pendingExplicitKey)) pendingExplicitKey = false;
+		if (!atExplicitKey) {
+			if (pendingExplicitKey) {
+				addEmptyScalarEvent(state);
+				pendingExplicitKey = false;
+			}
+		}
+		skipSeparationSpace(state, true);
+		ch = state.input.charCodeAt(state.position);
+		if ((state.line === entryLine || state.lineIndent > nodeIndent) && ch !== 0) throwError(state, "bad indentation of a mapping entry");
+		else if (state.lineIndent < nodeIndent) break;
+	}
+	if (!detected) return false;
+	if (atExplicitKey) addEmptyScalarEvent(state);
+	if (mappingOpened) addPopEvent(state);
+	return true;
+}
+function parseNode(state, parentIndent, nodeContext, allowToSeek, allowCompact, allowPropertyMapping = true) {
+	if (state.depth >= state.maxDepth) throwError(state, `nesting exceeded maxDepth (${state.maxDepth})`);
+	state.depth++;
+	let indentStatus = 1;
+	let atNewLine = false;
+	let hasContent = false;
+	let propertyStart = null;
+	const props = emptyProperties();
+	let allowBlockScalars = nodeContext === CONTEXT_BLOCK_OUT || nodeContext === CONTEXT_BLOCK_IN;
+	let allowBlockCollections = allowBlockScalars;
+	const allowBlockStyles = allowBlockScalars;
+	if (allowToSeek && skipSeparationSpace(state, true)) {
+		atNewLine = true;
+		if (state.lineIndent > parentIndent) indentStatus = 1;
+		else if (state.lineIndent === parentIndent) indentStatus = 0;
+		else indentStatus = -1;
+	}
+	if (indentStatus === 1) while (true) {
+		const ch = state.input.charCodeAt(state.position);
+		const propertyState = snapshotState(state);
+		if (atNewLine && indentStatus !== 1 && (ch === 33 || ch === 38)) break;
+		if (atNewLine && allowBlockStyles && (props.tagStart !== NO_RANGE$1 || props.anchorStart !== NO_RANGE$1) && (ch === 33 || ch === 38)) {
+			var _state$events$fallbac;
+			const fallbackState = snapshotState(state);
+			const flowIndent = parentIndent + 1;
+			if (readBlockMapping(state, state.position - state.lineStart, flowIndent, props) && ((_state$events$fallbac = state.events[fallbackState.eventsLength]) === null || _state$events$fallbac === void 0 ? void 0 : _state$events$fallbac.type) === 3) {
+				state.depth--;
+				return true;
+			}
+			restoreState(state, fallbackState);
+		}
+		if (atNewLine && (ch === 33 && props.tagStart !== NO_RANGE$1 || ch === 38 && props.anchorStart !== NO_RANGE$1)) break;
+		if (!readTagProperty(state, props, nodeContext === CONTEXT_FLOW_IN) && !readAnchorProperty(state, props)) break;
+		if (propertyStart === null) propertyStart = propertyState;
+		if (skipSeparationSpace(state, true)) {
+			atNewLine = true;
+			allowBlockCollections = allowBlockStyles;
+			if (state.lineIndent > parentIndent) indentStatus = 1;
+			else if (state.lineIndent === parentIndent) indentStatus = 0;
+			else indentStatus = -1;
+		} else allowBlockCollections = false;
+	}
+	if (allowBlockCollections) allowBlockCollections = atNewLine || allowCompact;
+	if (indentStatus === 1 || nodeContext === CONTEXT_BLOCK_OUT) {
+		const flowIndent = nodeContext === CONTEXT_FLOW_IN || nodeContext === CONTEXT_FLOW_OUT ? parentIndent : parentIndent + 1;
+		const blockIndent = state.position - state.lineStart;
+		if (indentStatus === 1) if (allowBlockCollections && (readBlockSequence(state, blockIndent, props) || readBlockMapping(state, blockIndent, flowIndent, props)) || readFlowCollection(state, flowIndent, props)) hasContent = true;
+		else {
+			const ch = state.input.charCodeAt(state.position);
+			if (propertyStart !== null && allowPropertyMapping && allowBlockStyles && !allowBlockCollections && ch !== 124 && ch !== 62) {
+				var _state$events$fallbac2;
+				const fallbackState = snapshotState(state);
+				const propertyIndent = propertyStart.position - propertyStart.lineStart;
+				restoreState(state, propertyStart);
+				if (readBlockMapping(state, propertyIndent, flowIndent, emptyProperties()) && ((_state$events$fallbac2 = state.events[fallbackState.eventsLength]) === null || _state$events$fallbac2 === void 0 ? void 0 : _state$events$fallbac2.type) === 3) hasContent = true;
+				else restoreState(state, fallbackState);
+			}
+			if (!hasContent && (allowBlockScalars && readBlockScalar(state, flowIndent, props) || readSingleQuotedScalar(state, flowIndent, props) || readDoubleQuotedScalar(state, flowIndent, props) || readAlias(state, props) || readPlainScalar(state, flowIndent, nodeContext, props))) hasContent = true;
+		}
+		else if (indentStatus === 0) hasContent = allowBlockCollections && readBlockSequence(state, blockIndent, props);
+	}
+	allowBlockScalars = allowBlockScalars && !hasContent;
+	if (!hasContent && (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1 || allowBlockScalars)) {
+		addScalarEvent(state, NO_RANGE$1, NO_RANGE$1, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+		hasContent = true;
+	}
+	state.depth--;
+	return hasContent || props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1;
+}
+function readDirective(state) {
+	if (state.lineIndent > 0 || state.input.charCodeAt(state.position) !== 37) return false;
+	state.position++;
+	const nameStart = state.position;
+	while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position))) state.position++;
+	const name = state.input.slice(nameStart, state.position);
+	const args = [];
+	if (name.length === 0) throwError(state, "directive name must not be less than one character in length");
+	while (state.input.charCodeAt(state.position) !== 0 && !isEol(state.input.charCodeAt(state.position))) {
+		while (isWhiteSpace(state.input.charCodeAt(state.position))) state.position++;
+		if (state.input.charCodeAt(state.position) === 35 || isEol(state.input.charCodeAt(state.position)) || state.input.charCodeAt(state.position) === 0) break;
+		const start = state.position;
+		while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position))) state.position++;
+		args.push(state.input.slice(start, state.position));
+	}
+	if (isEol(state.input.charCodeAt(state.position))) consumeLineBreak(state);
+	if (name === "YAML") {
+		if (state.directives.some((directive) => directive.kind === "yaml")) throwError(state, "duplication of %YAML directive");
+		if (args.length !== 1) throwError(state, "YAML directive accepts exactly one argument");
+		const match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+		if (match === null) throwError(state, "ill-formed argument of the YAML directive");
+		if (parseInt(match[1], 10) !== 1) throwError(state, "unacceptable YAML version of the document");
+		state.directives.push({
+			kind: "yaml",
+			version: args[0]
+		});
+	} else if (name === "TAG") {
+		if (args.length !== 2) throwError(state, "TAG directive accepts exactly two arguments");
+		const [handle, prefix] = args;
+		if (!PATTERN_TAG_HANDLE.test(handle)) throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
+		if (HAS_OWN.call(state.tagHandlers, handle)) throwError(state, `there is a previously declared suffix for "${handle}" tag handle`);
+		if (!PATTERN_TAG_PREFIX.test(prefix)) throwError(state, "ill-formed tag prefix (second argument) of the TAG directive");
+		state.tagHandlers[handle] = prefix;
+		state.directives.push({
+			kind: "tag",
+			handle,
+			prefix
+		});
+	}
+	return true;
+}
+function readDocument(state) {
+	state.directives = [];
+	state.tagHandlers = Object.create(null);
+	let hasDirectives = false;
+	skipSeparationSpace(state, true);
+	while (readDirective(state)) {
+		hasDirectives = true;
+		skipSeparationSpace(state, true);
+	}
+	let explicitStart = false;
+	let explicitEnd = false;
+	let allowCompact = true;
+	if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 3))) {
+		explicitStart = true;
+		const markerLine = state.line;
+		state.position += 3;
+		skipSeparationSpace(state, true);
+		allowCompact = state.line > markerLine;
+	} else if (hasDirectives) throwError(state, "directives end mark is expected");
+	const documentEventIndex = state.events.length;
+	if (!explicitStart && state.position === state.lineStart && state.input.charCodeAt(state.position) === 46 && testDocumentSeparator(state)) {
+		state.position += 3;
+		skipSeparationSpace(state, true);
+		return;
+	}
+	addDocumentEvent(state, explicitStart, false);
+	if (!parseNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, allowCompact, allowCompact)) addEmptyScalarEvent(state);
+	skipSeparationSpace(state, true);
+	if (state.position === state.lineStart && testDocumentSeparator(state)) {
+		explicitEnd = state.input.charCodeAt(state.position) === 46;
+		if (explicitEnd) {
+			const markerLine = state.line;
+			state.position += 3;
+			skipSeparationSpace(state, true);
+			if (state.line === markerLine && state.position < state.length) throwError(state, "end of the stream or a document separator is expected");
+		}
+	}
+	const documentEvent = state.events[documentEventIndex];
+	if ((documentEvent === null || documentEvent === void 0 ? void 0 : documentEvent.type) === 1) documentEvent.explicitEnd = explicitEnd;
+	addPopEvent(state);
+	if (!explicitEnd && state.position < state.length && !(state.position === state.lineStart && testDocumentSeparator(state))) throwError(state, "end of the stream or a document separator is expected");
+}
+function parseEvents(input, options) {
+	const length = input.length;
+	const state = _objectSpread2(_objectSpread2(_objectSpread2({}, DEFAULT_PARSER_OPTIONS), options), {}, {
+		input: `${input}\0`,
+		length,
+		position: 0,
+		line: 0,
+		lineStart: 0,
+		lineIndent: 0,
+		firstTabInLine: -1,
+		depth: 0,
+		directives: [],
+		tagHandlers: Object.create(null),
+		events: []
+	});
+	const nullpos = input.indexOf("\0");
+	if (nullpos !== -1) throwErrorAt(input, nullpos, "null byte is not allowed in input", state.filename);
+	if (state.input.charCodeAt(state.position) === 65279) state.position++;
+	while (state.position < state.length) {
+		skipSeparationSpace(state, true);
+		if (state.position >= state.length) break;
+		const documentStart = state.position;
+		readDocument(state);
+		if (state.position === documentStart)
+ /* c8 ignore next */
+		throwError(state, "can not read a document");
+	}
+	return state.events;
+}
+//#endregion
+//#region src/load.ts
+var DEFAULT_LOAD_OPTIONS = _objectSpread2(_objectSpread2({}, DEFAULT_PARSER_OPTIONS), DEFAULT_CONSTRUCTOR_OPTIONS);
+function loadDocuments(input, options = {}) {
+	const opts = _objectSpread2(_objectSpread2({}, DEFAULT_LOAD_OPTIONS), options);
+	const source = String(input);
+	const PARSER_OPT_KEYS = Object.keys(DEFAULT_PARSER_OPTIONS);
+	const CONSTRUCTOR_OPT_KEYS = Object.keys(DEFAULT_CONSTRUCTOR_OPTIONS);
+	return constructFromEvents(parseEvents(source, pick(opts, PARSER_OPT_KEYS)), _objectSpread2(_objectSpread2({}, pick(opts, CONSTRUCTOR_OPT_KEYS)), {}, { source }));
+}
+function loadAll(input, iteratorOrOptions, options) {
+	let iterator = null;
+	if (typeof iteratorOrOptions === "function") iterator = iteratorOrOptions;
+	else if (iteratorOrOptions !== null && typeof iteratorOrOptions === "object") options = iteratorOrOptions;
+	const documents = loadDocuments(input, options);
+	if (iterator === null) return documents;
+	for (const document of documents) iterator(document);
+}
+function load(input, options) {
+	const documents = loadDocuments(input, options);
+	if (documents.length === 0) throw new YAMLException("expected a document, but the input is empty");
+	if (documents.length === 1) return documents[0];
+	throw new YAMLException("expected a single document in the stream, but found more");
+}
+//#endregion
+//#region src/ast/nodes.ts
+var Style = class {
+	constructor() {
+		_defineProperty(this, "tagged", false);
+		_defineProperty(this, "flow", false);
+		_defineProperty(this, "singleQuoted", false);
+		_defineProperty(this, "doubleQuoted", false);
+		_defineProperty(this, "literal", false);
+		_defineProperty(this, "folded", false);
+	}
+};
+//#endregion
+//#region src/ast/from_js.ts
+var INVALID = Symbol("INVALID");
+function buildRepresentTypes(schema) {
+	const defaultTags = new Set([
+		schema.defaultScalarTag,
+		schema.defaultSequenceTag,
+		schema.defaultMappingTag
+	].filter((t) => t !== void 0));
+	const implicitScalars = schema.implicitScalarTags;
+	const explicitTags = schema.tags.filter((t) => !(t.nodeKind === "scalar" && t.implicit) && !defaultTags.has(t));
+	const defaultTagsLast = schema.tags.filter((t) => defaultTags.has(t));
+	return [
+		...implicitScalars.map((tag) => ({
+			tag,
+			implicitTag: true
+		})),
+		...explicitTags.map((tag) => ({
+			tag,
+			implicitTag: false
+		})),
+		...defaultTagsLast.map((tag) => ({
+			tag,
+			implicitTag: true
+		}))
+	];
+}
+function matchTag(state, object) {
+	for (let index = 0, length = state.representTypes.length; index < length; index += 1) {
+		const { tag, implicitTag } = state.representTypes[index];
+		if (tag.identify && tag.identify(object)) {
+			let tagName;
+			if (tag.matchByTagPrefix && tag.representTagName) tagName = tag.representTagName(object);
+			else tagName = tag.tagName;
+			return {
+				tag,
+				tagName,
+				implicitTag
+			};
+		}
+	}
+	return null;
+}
+function build(state, object) {
+	if (!state.noRefs && object !== null && typeof object === "object") {
+		const existing = state.refs.get(object);
+		if (existing) {
+			if (existing.anchor === void 0) existing.anchor = `ref_${state.refCounter++}`;
+			return {
+				kind: "alias",
+				tag: "",
+				style: new Style(),
+				anchor: existing.anchor
+			};
+		}
+	}
+	const matched = matchTag(state, object);
+	if (!matched) {
+		if (object === void 0) return INVALID;
+		if (state.skipInvalid) return INVALID;
+		throw new YAMLException(`unacceptable kind of an object to dump ${Object.prototype.toString.call(object)}`);
+	}
+	const { tag, tagName, implicitTag } = matched;
+	const nodeTagName = implicitTag ? tagName : tagNameShort(tagName);
+	if (tag.nodeKind === "scalar") {
+		const style = new Style();
+		style.tagged = !implicitTag;
+		return {
+			kind: "scalar",
+			tag: nodeTagName,
+			style,
+			value: tag.represent(object)
+		};
+	}
+	if (tag.nodeKind === "sequence") {
+		const container = tag.represent(object);
+		const style = new Style();
+		style.tagged = !implicitTag;
+		const node = {
+			kind: "sequence",
+			tag: nodeTagName,
+			style,
+			items: []
+		};
+		if (!state.noRefs) state.refs.set(object, node);
+		for (let index = 0, length = container.length; index < length; index += 1) {
+			let item = build(state, container[index]);
+			if (item === INVALID && container[index] === void 0) item = build(state, null);
+			if (item === INVALID) continue;
+			node.items.push(item);
+		}
+		return node;
+	}
+	const map = tag.represent(object);
+	const style = new Style();
+	style.tagged = !implicitTag;
+	const node = {
+		kind: "mapping",
+		tag: nodeTagName,
+		style,
+		items: []
+	};
+	if (!state.noRefs) state.refs.set(object, node);
+	for (const [objectKey, objectValue] of map) {
+		const key = build(state, objectKey);
+		if (key === INVALID) continue;
+		const value = build(state, objectValue);
+		if (value === INVALID) continue;
+		node.items.push({
+			key,
+			value
+		});
+	}
+	return node;
+}
+function jsToAst(input, schema, options = {}) {
+	var _options$noRefs, _options$skipInvalid;
+	const root = build({
+		representTypes: buildRepresentTypes(schema),
+		noRefs: (_options$noRefs = options.noRefs) !== null && _options$noRefs !== void 0 ? _options$noRefs : false,
+		skipInvalid: (_options$skipInvalid = options.skipInvalid) !== null && _options$skipInvalid !== void 0 ? _options$skipInvalid : false,
+		refs: /* @__PURE__ */ new Map(),
+		refCounter: 0
+	}, input);
+	return [{
+		contents: root === INVALID ? null : root,
+		directives: []
+	}];
+}
+//#endregion
+//#region src/ast/visit.ts
+var VISIT_BREAK = Symbol("visit:break");
+var VISIT_SKIP = Symbol("visit:skip");
+function visitNode(node, visitor, ctx) {
+	const control = visitor(node, ctx);
+	if (control === VISIT_BREAK) return true;
+	if (control === VISIT_SKIP) return false;
+	const depth = ctx.depth + 1;
+	switch (node.kind) {
+		case "sequence":
+			for (const item of node.items) if (visitNode(item, visitor, {
+				depth,
+				parent: node,
+				isKey: false
+			})) return true;
+			break;
+		case "mapping":
+			for (const { key, value } of node.items) {
+				if (visitNode(key, visitor, {
+					depth,
+					parent: node,
+					isKey: true
+				})) return true;
+				if (visitNode(value, visitor, {
+					depth,
+					parent: node,
+					isKey: false
+				})) return true;
+			}
+			break;
+	}
+	return false;
+}
+function visit(documents, visitor) {
+	for (const doc of documents) if (doc.contents && visitNode(doc.contents, visitor, {
+		depth: 0,
+		parent: null,
+		isKey: false
+	})) return;
+}
+//#endregion
+//#region src/ast/presenter.ts
+var CHAR_BOM = 65279;
+var CHAR_TAB = 9;
+var CHAR_LINE_FEED = 10;
+var CHAR_CARRIAGE_RETURN = 13;
+var CHAR_SPACE = 32;
+var CHAR_EXCLAMATION = 33;
+var CHAR_DOUBLE_QUOTE = 34;
+var CHAR_SHARP = 35;
+var CHAR_PERCENT = 37;
+var CHAR_AMPERSAND = 38;
+var CHAR_SINGLE_QUOTE = 39;
+var CHAR_ASTERISK = 42;
+var CHAR_COMMA = 44;
+var CHAR_MINUS = 45;
+var CHAR_COLON = 58;
+var CHAR_EQUALS = 61;
+var CHAR_GREATER_THAN = 62;
+var CHAR_QUESTION = 63;
+var CHAR_COMMERCIAL_AT = 64;
+var CHAR_LEFT_SQUARE_BRACKET = 91;
+var CHAR_RIGHT_SQUARE_BRACKET = 93;
+var CHAR_GRAVE_ACCENT = 96;
+var CHAR_LEFT_CURLY_BRACKET = 123;
+var CHAR_VERTICAL_LINE = 124;
+var CHAR_RIGHT_CURLY_BRACKET = 125;
+var ESCAPE_SEQUENCES = {};
+ESCAPE_SEQUENCES[0] = "\\0";
+ESCAPE_SEQUENCES[7] = "\\a";
+ESCAPE_SEQUENCES[8] = "\\b";
+ESCAPE_SEQUENCES[9] = "\\t";
+ESCAPE_SEQUENCES[10] = "\\n";
+ESCAPE_SEQUENCES[11] = "\\v";
+ESCAPE_SEQUENCES[12] = "\\f";
+ESCAPE_SEQUENCES[13] = "\\r";
+ESCAPE_SEQUENCES[27] = "\\e";
+ESCAPE_SEQUENCES[34] = "\\\"";
+ESCAPE_SEQUENCES[92] = "\\\\";
+ESCAPE_SEQUENCES[133] = "\\N";
+ESCAPE_SEQUENCES[160] = "\\_";
+ESCAPE_SEQUENCES[8232] = "\\L";
+ESCAPE_SEQUENCES[8233] = "\\P";
+var DEFAULT_PRESENTER_OPTIONS = {
+	indent: 2,
+	seqNoIndent: false,
+	seqInlineFirst: true,
+	sortKeys: false,
+	lineWidth: 80,
+	flowBracketPadding: false,
+	flowSkipCommaSpace: false,
+	flowSkipColonSpace: false,
+	quoteFlowKeys: false,
+	quoteStyle: "single",
+	forceQuotes: false,
+	tagBeforeAnchor: false
+};
+function nodeTagShort(node) {
+	return node.style.tagged ? node.tag : tagNameShort(node.tag);
+}
+function createPresenterState(options) {
+	const opts = _objectSpread2(_objectSpread2({}, DEFAULT_PRESENTER_OPTIONS), options);
+	return _objectSpread2(_objectSpread2({}, opts), {}, {
+		defaultScalarTagName: opts.schema.defaultScalarTag.tagName,
+		implicitResolvers: opts.schema.implicitScalarTags
+	});
+}
+function encodeNonPrintable(character) {
+	const string = character.toString(16).toUpperCase();
+	const handle = character <= 255 ? "x" : "u";
+	const length = character <= 255 ? 2 : 4;
+	return `\\${handle}${"0".repeat(length - string.length)}${string}`;
+}
+function indentString(string, spaces) {
+	const ind = " ".repeat(spaces);
+	let position = 0;
+	let result = "";
+	const length = string.length;
+	while (position < length) {
+		let line;
+		const next = string.indexOf("\n", position);
+		if (next === -1) {
+			line = string.slice(position);
+			position = length;
+		} else {
+			line = string.slice(position, next + 1);
+			position = next + 1;
+		}
+		if (line.length && line !== "\n") result += ind;
+		result += line;
+	}
+	return result;
+}
+function generateNextLine(state, level) {
+	return `\n${" ".repeat(state.indent * level)}`;
+}
+function scalarLayout(state, level) {
+	const indent = state.indent * Math.max(1, level);
+	return {
+		indent,
+		blockIndent: level === 0 ? state.indent + 1 : state.indent,
+		lineWidth: state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent)
+	};
+}
+function resolveImplicitTag(state, str) {
+	for (let index = 0, length = state.implicitResolvers.length; index < length; index += 1) {
+		const tagDefinition = state.implicitResolvers[index];
+		if (tagDefinition.resolve(str, false, tagDefinition.tagName) !== NOT_RESOLVED) return tagDefinition.tagName;
+	}
+	return state.defaultScalarTagName;
+}
+function isWhitespace(c) {
+	return c === CHAR_SPACE || c === CHAR_TAB;
+}
+function startsWithDocumentSeparator(string) {
+	const marker = string.charCodeAt(0);
+	if (marker !== CHAR_MINUS && marker !== 46 || string.charCodeAt(1) !== marker || string.charCodeAt(2) !== marker) return false;
+	if (string.length === 3) return true;
+	const following = string.charCodeAt(3);
+	return isWhitespace(following) || following === CHAR_CARRIAGE_RETURN || following === CHAR_LINE_FEED;
+}
+function isPrintable(c) {
+	return c >= 32 && c <= 126 || c >= 161 && c <= 55295 && c !== 8232 && c !== 8233 || c >= 57344 && c <= 65533 && c !== CHAR_BOM || c >= 65536 && c <= 1114111;
+}
+function isNsCharOrWhitespace(c) {
+	return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
+}
+function isPlainSafe(c, prev, inblock) {
+	const cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+	const cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+	return (inblock ? cIsNsCharOrWhitespace : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar && (inblock || c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET);
+}
+function isPlainSafeFirst(c) {
+	return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
+}
+function isPlainSafeAtStart(string, inblock) {
+	const first = codePointAt(string, 0);
+	if (isPlainSafeFirst(first)) return true;
+	if (string.length > 1 && (first === CHAR_MINUS || first === CHAR_QUESTION || first === CHAR_COLON)) {
+		const second = codePointAt(string, 1);
+		return !isWhitespace(second) && isPlainSafe(second, first, inblock);
+	}
+	return false;
+}
+function isPlainSafeLast(c) {
+	return !isWhitespace(c) && c !== CHAR_COLON;
+}
+function codePointAt(string, pos) {
+	const first = string.charCodeAt(pos);
+	let second;
+	if (first >= 55296 && first <= 56319 && pos + 1 < string.length) {
+		second = string.charCodeAt(pos + 1);
+		if (second >= 56320 && second <= 57343) return (first - 55296) * 1024 + second - 56320 + 65536;
+	}
+	return first;
+}
+function needIndentIndicator(string) {
+	return /^\n* /.test(string);
+}
+var STYLE_PLAIN = 1;
+var STYLE_SINGLE = 2;
+var STYLE_LITERAL = 3;
+var STYLE_FOLDED = 4;
+var STYLE_DOUBLE = 5;
+function chooseScalarStyle(state, string, layout, singleLineOnly, forceQuote, inblock) {
+	const { blockIndent, lineWidth } = layout;
+	let i;
+	let char = 0;
+	let prevChar = -1;
+	let hasLineBreak = false;
+	let hasFoldableLine = false;
+	const shouldTrackWidth = lineWidth !== -1;
+	let previousLineBreak = -1;
+	let plain = !startsWithDocumentSeparator(string) && isPlainSafeAtStart(string, inblock) && isPlainSafeLast(codePointAt(string, string.length - 1));
+	if (singleLineOnly || forceQuote) for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+		char = codePointAt(string, i);
+		if (!isPrintable(char)) return STYLE_DOUBLE;
+		plain = plain && isPlainSafe(char, prevChar, inblock);
+		prevChar = char;
+	}
+	else {
+		for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+			char = codePointAt(string, i);
+			if (char === CHAR_LINE_FEED) {
+				hasLineBreak = true;
+				if (shouldTrackWidth) {
+					hasFoldableLine = hasFoldableLine || i - previousLineBreak - 1 > lineWidth && !isMoreIndented(string[previousLineBreak + 1]);
+					previousLineBreak = i;
+				}
+			} else if (!isPrintable(char)) return STYLE_DOUBLE;
+			plain = plain && isPlainSafe(char, prevChar, inblock);
+			prevChar = char;
+		}
+		hasFoldableLine = hasFoldableLine || shouldTrackWidth && i - previousLineBreak - 1 > lineWidth && !isMoreIndented(string[previousLineBreak + 1]);
+	}
+	if (!hasLineBreak && !hasFoldableLine) {
+		if (plain && !forceQuote) return STYLE_PLAIN;
+		return state.quoteStyle === "double" ? STYLE_DOUBLE : STYLE_SINGLE;
+	}
+	if (blockIndent > 9 && needIndentIndicator(string)) return STYLE_DOUBLE;
+	return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+}
+function renderScalarStyle(string, style, layout) {
+	const { indent, blockIndent, lineWidth } = layout;
+	switch (style) {
+		case STYLE_PLAIN: return encodeFlowBreaks(string, indent);
+		case STYLE_SINGLE: return `'${encodeFlowBreaks(string, indent).replace(/'/g, "''")}'`;
+		case STYLE_LITERAL: return "|" + blockHeader(string, blockIndent) + dropEndingNewline(indentString(string, indent));
+		case STYLE_FOLDED: return ">" + blockHeader(string, blockIndent) + dropEndingNewline(indentString(foldBlockScalar(string, lineWidth), indent));
+		case STYLE_DOUBLE: return `"${escapeString(string)}"`;
+	}
+}
+function resolveScalarStyle(state, node, layout, iskey, inblock) {
+	const singleLineOnly = iskey || !inblock;
+	if (node.style.singleQuoted) return STYLE_SINGLE;
+	if (node.style.doubleQuoted) return STYLE_DOUBLE;
+	if (!singleLineOnly) {
+		if (node.style.literal) return STYLE_LITERAL;
+		if (node.style.folded) return STYLE_FOLDED;
+	}
+	const string = node.value;
+	if (string.length === 0) {
+		if (node.style.tagged || resolveImplicitTag(state, string) === node.tag) return STYLE_PLAIN;
+		return state.quoteStyle === "double" ? STYLE_DOUBLE : STYLE_SINGLE;
+	}
+	const style = chooseScalarStyle(state, string, layout, singleLineOnly, state.forceQuotes && !iskey, inblock);
+	if (style === STYLE_PLAIN && !node.style.tagged && resolveImplicitTag(state, string) !== node.tag) return state.quoteStyle === "double" ? STYLE_DOUBLE : STYLE_SINGLE;
+	return style;
+}
+function blockHeader(string, indentPerLevel) {
+	const indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
+	const clip = string[string.length - 1] === "\n";
+	return `${indentIndicator}${clip && (string[string.length - 2] === "\n" || string === "\n") ? "+" : clip ? "" : "-"}\n`;
+}
+function encodeFlowBreaks(string, indent) {
+	let nextLF = string.indexOf("\n");
+	if (nextLF === -1) return string;
+	const pad = " ".repeat(indent);
+	let result = string.slice(0, nextLF);
+	const lineRe = /(\n+)([^\n]*)/g;
+	lineRe.lastIndex = nextLF;
+	let match;
+	while (match = lineRe.exec(string)) {
+		const breaks = match[1].length;
+		const line = match[2];
+		result += "\n".repeat(breaks + 1) + pad + line;
+	}
+	return result;
+}
+function dropEndingNewline(string) {
+	return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
+}
+function isMoreIndented(char) {
+	return char === " " || char === "	";
+}
+function foldBlockScalar(string, width) {
+	const lineRe = /(\n+)([^\n]*)/g;
+	let nextLF = string.indexOf("\n");
+	if (nextLF === -1) nextLF = string.length;
+	lineRe.lastIndex = nextLF;
+	let result = foldLine(string.slice(0, nextLF), width);
+	let prevMoreIndented = string[0] === "\n" || isMoreIndented(string[0]);
+	let moreIndented;
+	let match;
+	while (match = lineRe.exec(string)) {
+		const prefix = match[1];
+		const line = match[2];
+		moreIndented = line !== "" && isMoreIndented(line[0]);
+		result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
+		prevMoreIndented = moreIndented;
+	}
+	return result;
+}
+function foldLine(line, width) {
+	if (line === "" || isMoreIndented(line[0])) return line;
+	const breakRe = / [^ \t]/g;
+	let match;
+	let start = 0;
+	let end;
+	let curr = 0;
+	let next = 0;
+	let result = "";
+	while (match = breakRe.exec(line)) {
+		next = match.index;
+		if (next - start > width) {
+			end = curr > start ? curr : next;
+			result += `\n${line.slice(start, end)}`;
+			start = end + 1;
+		}
+		curr = next;
+	}
+	result += "\n";
+	if (line.length - start > width && curr > start) result += `${line.slice(start, curr)}\n${line.slice(curr + 1)}`;
+	else result += line.slice(start);
+	return result.slice(1);
+}
+function escapeString(string) {
+	let result = "";
+	let char = 0;
+	for (let i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+		char = codePointAt(string, i);
+		const escapeSeq = ESCAPE_SEQUENCES[char];
+		if (escapeSeq) {
+			result += escapeSeq;
+			continue;
+		}
+		if (isPrintable(char)) {
+			result += string[i];
+			if (char >= 65536) result += string[i + 1];
+			continue;
+		}
+		result += encodeNonPrintable(char);
+	}
+	return result;
+}
+function writeFlowSequence(state, level, node) {
+	let result = "";
+	for (let index = 0, length = node.items.length; index < length; index += 1) {
+		const item = writeNode(state, level, node.items[index], {});
+		if (result !== "") result += `,${!state.flowSkipCommaSpace ? " " : ""}`;
+		result += item;
+	}
+	const pad = state.flowBracketPadding && result !== "" ? " " : "";
+	return `[${pad}${result}${pad}]`;
+}
+function writeBlockSequence(state, level, node, compact) {
+	let result = "";
+	for (let index = 0, length = node.items.length; index < length; index += 1) {
+		const item = writeNode(state, level + 1, node.items[index], {
+			block: true,
+			compact: state.seqInlineFirst,
+			isblockseq: true
+		});
+		if (!compact || result !== "") result += generateNextLine(state, level);
+		if (item === "" || CHAR_LINE_FEED === item.charCodeAt(0)) result += "-";
+		else result += "- ";
+		result += item;
+	}
+	return result;
+}
+function writeFlowMapping(state, level, node) {
+	let result = "";
+	const items = sortMappingItems(state, node.items);
+	for (const { key, value } of items) {
+		let pairBuffer = "";
+		if (result !== "") pairBuffer += `,${!state.flowSkipCommaSpace ? " " : ""}`;
+		const keyText = writeNode(state, level, key, { iskey: true });
+		const explicitPair = keyText.length > 1024;
+		if (explicitPair) pairBuffer += "? ";
+		else if (state.quoteFlowKeys) pairBuffer += "\"";
+		const valueText = writeNode(state, level, value, {});
+		const sep = state.flowSkipColonSpace || valueText === "" ? "" : " ";
+		pairBuffer += `${keyText}${state.quoteFlowKeys && !explicitPair ? "\"" : ""}:${sep}${valueText}`;
+		result += pairBuffer;
+	}
+	const pad = state.flowBracketPadding && result !== "" ? " " : "";
+	return `{${pad}${result}${pad}}`;
+}
+function sortKeyValue(key) {
+	return key.kind === "scalar" ? key.value : key;
+}
+function sortMappingItems(state, items) {
+	if (!state.sortKeys) return items;
+	const copy = items.slice();
+	if (state.sortKeys === true) copy.sort((a, b) => {
+		const x = sortKeyValue(a.key);
+		const y = sortKeyValue(b.key);
+		if (x < y) return -1;
+		if (x > y) return 1;
+		return 0;
+	});
+	else {
+		const fn = state.sortKeys;
+		copy.sort((a, b) => fn(sortKeyValue(a.key), sortKeyValue(b.key)));
+	}
+	return copy;
+}
+function writeBlockMapping(state, level, node, compact) {
+	let result = "";
+	const items = sortMappingItems(state, node.items);
+	for (let index = 0, length = items.length; index < length; index += 1) {
+		let pairBuffer = "";
+		if (!compact || result !== "") pairBuffer += generateNextLine(state, level);
+		const { key, value } = items[index];
+		const keyIsBlock = (key.kind === "mapping" || key.kind === "sequence") && !key.style.flow && key.items.length !== 0 || key.kind === "scalar" && (key.style.literal || key.style.folded);
+		const keyText = keyIsBlock ? writeNode(state, level + 1, key, {
+			block: true,
+			compact: true,
+			isblockseq: !cannotBeCompact(state, key, level + 1)
+		}) : writeNode(state, level + 1, key, {
+			block: true,
+			compact: true,
+			iskey: true
+		});
+		const keyHasLineBreak = key.kind === "scalar" && key.value.indexOf("\n") !== -1;
+		const explicitPair = keyIsBlock || keyHasLineBreak || keyText.length > 1024;
+		if (explicitPair) if (keyText && CHAR_LINE_FEED === keyText.charCodeAt(0)) pairBuffer += "?";
+		else pairBuffer += "? ";
+		pairBuffer += keyText;
+		if (explicitPair) pairBuffer += generateNextLine(state, level);
+		const valueText = writeNode(state, level + 1, value, {
+			block: true,
+			compact: explicitPair,
+			isblockseq: explicitPair && !cannotBeCompact(state, value, level + 1)
+		});
+		const keyIsBareProps = key.kind === "scalar" && key.value === "" && keyText !== "" && keyText.charCodeAt(keyText.length - 1) !== CHAR_SINGLE_QUOTE && keyText.charCodeAt(keyText.length - 1) !== CHAR_DOUBLE_QUOTE;
+		const keyColonSep = !explicitPair && (key.kind === "alias" || keyIsBareProps) ? " " : "";
+		if (valueText === "" || CHAR_LINE_FEED === valueText.charCodeAt(0)) pairBuffer += `${keyColonSep}:`;
+		else pairBuffer += `${keyColonSep}: `;
+		pairBuffer += valueText;
+		result += pairBuffer;
+	}
+	return result;
+}
+function cannotBeCompact(state, node, level) {
+	return node.style.tagged || node.anchor !== void 0 || state.indent < 2 && level > 0;
+}
+function writeNode(state, level, node, ctx) {
+	var _ctx$compact;
+	if (node.kind === "alias") return `*${node.anchor}`;
+	const { block = false, iskey = false, isblockseq = false } = ctx;
+	let compact = (_ctx$compact = ctx.compact) !== null && _ctx$compact !== void 0 ? _ctx$compact : false;
+	const hasAnchor = node.anchor !== void 0;
+	if (cannotBeCompact(state, node, level)) compact = false;
+	let body;
+	let shouldPrintTag = node.style.tagged;
+	const useBlockCollection = block && (node.kind === "mapping" || node.kind === "sequence") && !node.style.flow && node.items.length !== 0;
+	if (node.kind === "mapping") if (useBlockCollection) body = writeBlockMapping(state, level, node, compact);
+	else body = writeFlowMapping(state, level, node);
+	else if (node.kind === "sequence") if (useBlockCollection) if (state.seqNoIndent && !isblockseq && level > 0) body = writeBlockSequence(state, level - 1, node, compact);
+	else body = writeBlockSequence(state, level, node, compact);
+	else body = writeFlowSequence(state, level, node);
+	else {
+		const layout = scalarLayout(state, level);
+		const style = resolveScalarStyle(state, node, layout, iskey, block);
+		body = renderScalarStyle(node.value, style, layout);
+		shouldPrintTag = node.style.tagged || style !== STYLE_PLAIN && node.tag !== state.defaultScalarTagName;
+	}
+	if (useBlockCollection && compact && level > 0 && state.indent > 2) body = `${" ".repeat(state.indent - 2)}${body}`;
+	if (shouldPrintTag || hasAnchor) {
+		const props = [];
+		const tag = shouldPrintTag ? nodeTagShort(node) : null;
+		const anchor = hasAnchor ? `&${node.anchor}` : null;
+		if (state.tagBeforeAnchor) {
+			if (tag !== null) props.push(tag);
+			if (anchor !== null) props.push(anchor);
+		} else {
+			if (anchor !== null) props.push(anchor);
+			if (tag !== null) props.push(tag);
+		}
+		const sep = body === "" || body.charCodeAt(0) === CHAR_LINE_FEED ? "" : " ";
+		body = `${props.join(" ")}${sep}${body}`;
+	}
+	return body;
+}
+function rootStartsOwnLine(node) {
+	return (node.kind === "sequence" || node.kind === "mapping") && !node.style.flow && node.items.length !== 0 && !node.style.tagged && node.anchor === void 0;
+}
+function isOpenEnded(node) {
+	let leaf = node;
+	while ((leaf.kind === "sequence" || leaf.kind === "mapping") && !leaf.style.flow && leaf.items.length !== 0) leaf = leaf.kind === "sequence" ? leaf.items[leaf.items.length - 1] : leaf.items[leaf.items.length - 1].value;
+	if (leaf.kind !== "scalar" || !(leaf.style.literal || leaf.style.folded)) return false;
+	const { value } = leaf;
+	return value.endsWith("\n\n") || value === "\n";
+}
+function writeDocumentDirectives(doc) {
+	let result = "";
+	for (const directive of doc.directives) {
+		if (directive.kind === "yaml") {
+			result += `%YAML ${directive.version}\n`;
+			continue;
+		}
+		const { handle, prefix } = directive;
+		result += `%TAG ${handle} ${prefix}\n`;
+	}
+	return result;
+}
+function present(documents, options) {
+	const state = createPresenterState(options);
+	let result = "";
+	let previousEnded = false;
+	for (let index = 0; index < documents.length; index += 1) {
+		const doc = documents[index];
+		const directives = writeDocumentDirectives(doc);
+		const hasDirectives = directives !== "";
+		const marker = doc.explicitStart || hasDirectives || index > 0 && !previousEnded;
+		result += directives;
+		if (doc.contents === null) {
+			if (marker) result += "---\n";
+		} else if (marker) {
+			const body = writeNode(state, 0, doc.contents, {
+				block: true,
+				compact: true
+			});
+			const sep = body === "" ? "" : hasDirectives || rootStartsOwnLine(doc.contents) ? "\n" : " ";
+			result += `---${sep}${body}\n`;
+		} else result += writeNode(state, 0, doc.contents, {
+			block: true,
+			compact: true
+		}) + "\n";
+		previousEnded = doc.explicitEnd || doc.contents !== null && isOpenEnded(doc.contents);
+		if (previousEnded) result += "...\n";
+	}
+	return result;
+}
+//#endregion
+//#region src/dump.ts
+var DEFAULT_DUMP_SCHEMA = YAML11_SCHEMA.withTags(_objectSpread2(_objectSpread2({}, intYaml11Tag), {}, { resolve: (source, isExplicit, tagName) => {
+	const result = intYaml11Tag.resolve(source, isExplicit, tagName);
+	return result === NOT_RESOLVED ? intCoreTag.resolve(source, isExplicit, tagName) : result;
+} }), _objectSpread2(_objectSpread2({}, floatYaml11Tag), {}, { resolve: (source, isExplicit, tagName) => {
+	const result = floatYaml11Tag.resolve(source, isExplicit, tagName);
+	return result === NOT_RESOLVED ? floatCoreTag.resolve(source, isExplicit, tagName) : result;
+} }));
+var DEFAULT_DUMP_OPTIONS = _objectSpread2(_objectSpread2({}, DEFAULT_PRESENTER_OPTIONS), {}, {
+	schema: DEFAULT_DUMP_SCHEMA,
+	skipInvalid: false,
+	noRefs: false,
+	flowLevel: -1,
+	transform: () => {}
+});
+function dump(input, options = {}) {
+	const opts = _objectSpread2(_objectSpread2({}, DEFAULT_DUMP_OPTIONS), options);
+	const documents = jsToAst(input, opts.schema, {
+		noRefs: opts.noRefs,
+		skipInvalid: opts.skipInvalid
+	});
+	if (opts.flowLevel >= 0) visit(documents, (node, ctx) => {
+		if (ctx.depth < opts.flowLevel) return;
+		node.style.flow = true;
+		return VISIT_SKIP;
+	});
+	opts.transform(documents);
+	return present(documents, _objectSpread2(_objectSpread2({}, pick(opts, Object.keys(DEFAULT_PRESENTER_OPTIONS))), {}, { schema: opts.schema }));
+}
+//#endregion
+//#region src/ast/from_events.ts
+var NO_RANGE = -1;
+function eventPosition(event) {
+	if ("tagStart" in event && event.tagStart !== NO_RANGE) return event.tagStart;
+	if ("anchorStart" in event && event.anchorStart !== NO_RANGE) return event.anchorStart;
+	if ("valueStart" in event && event.valueStart !== NO_RANGE) return event.valueStart;
+	if ("start" in event) return event.start;
+	return 0;
+}
+function rawTag(state, event) {
+	return event.tagStart === NO_RANGE ? "" : state.source.slice(event.tagStart, event.tagEnd);
+}
+function anchorName(state, event) {
+	return event.anchorStart === NO_RANGE ? void 0 : state.source.slice(event.anchorStart, event.anchorEnd);
+}
+function implicitScalarTagName(state, source) {
+	var _schema$implicitScala;
+	const { schema } = state;
+	const candidates = (_schema$implicitScala = schema.implicitScalarByFirstChar.get(source.charAt(0))) !== null && _schema$implicitScala !== void 0 ? _schema$implicitScala : schema.implicitScalarAnyFirstChar;
+	for (const tag of candidates) if (tag.resolve(source, false, tag.tagName) !== NOT_RESOLVED) return tag.tagName;
+	return schema.defaultScalarTag.tagName;
+}
+function buildScalar(state, event) {
+	const value = getScalarValue(state.source, event);
+	const raw = rawTag(state, event);
+	const style = new Style();
+	switch (event.style) {
+		case 2:
+			style.singleQuoted = true;
+			break;
+		case 3:
+			style.doubleQuoted = true;
+			break;
+		case 4:
+			style.literal = true;
+			break;
+		case 5:
+			style.folded = true;
+			break;
+	}
+	let tag;
+	if (raw !== "") {
+		style.tagged = true;
+		tag = raw;
+	} else if (event.style === 1) tag = implicitScalarTagName(state, value);
+	else tag = state.schema.defaultScalarTag.tagName;
+	return {
+		kind: "scalar",
+		tag,
+		style,
+		anchor: anchorName(state, event),
+		value
+	};
+}
+function buildCollection(state, event, defaultTagName) {
+	const raw = rawTag(state, event);
+	const style = new Style();
+	if (event.style === 2) style.flow = true;
+	let tag;
+	if (raw === "") tag = defaultTagName;
+	else {
+		tag = raw;
+		style.tagged = true;
+	}
+	return {
+		tag,
+		style,
+		anchor: anchorName(state, event)
+	};
+}
+function addNode(state, node) {
+	const frame = state.frames[state.frames.length - 1];
+	if (frame.kind === "document") frame.doc.contents = node;
+	else if (frame.kind === "sequence") frame.node.items.push(node);
+	else if (frame.key) {
+		frame.node.items.push({
+			key: frame.key,
+			value: node
+		});
+		frame.key = null;
+	} else frame.key = node;
+}
+function eventsToAst(events, options) {
+	const state = {
+		source: options.source,
+		schema: options.schema,
+		eventIndex: 0,
+		position: 0,
+		frames: [],
+		documents: []
+	};
+	while (state.eventIndex < events.length) {
+		const event = events[state.eventIndex++];
+		state.position = eventPosition(event);
+		switch (event.type) {
+			case 1: {
+				const doc = {
+					contents: null,
+					explicitStart: event.explicitStart,
+					explicitEnd: event.explicitEnd,
+					directives: event.directives
+				};
+				state.frames.push({
+					kind: "document",
+					doc
+				});
+				break;
+			}
+			case 4:
+				addNode(state, buildScalar(state, event));
+				break;
+			case 2: {
+				const { tag, style, anchor } = buildCollection(state, event, "tag:yaml.org,2002:seq");
+				const node = {
+					kind: "sequence",
+					tag,
+					style,
+					anchor,
+					items: []
+				};
+				state.frames.push({
+					kind: "sequence",
+					node
+				});
+				break;
+			}
+			case 3: {
+				const { tag, style, anchor } = buildCollection(state, event, "tag:yaml.org,2002:map");
+				const node = {
+					kind: "mapping",
+					tag,
+					style,
+					anchor,
+					items: []
+				};
+				state.frames.push({
+					kind: "mapping",
+					node,
+					key: null
+				});
+				break;
+			}
+			case 5: {
+				const name = state.source.slice(event.anchorStart, event.anchorEnd);
+				addNode(state, {
+					kind: "alias",
+					tag: "",
+					style: new Style(),
+					anchor: name
+				});
+				break;
+			}
+			case 6: {
+				const frame = state.frames.pop();
+				if (frame.kind === "mapping" && frame.key) throw new Error("incomplete mapping pair in event stream");
+				if (frame.kind === "document") state.documents.push(frame.doc);
+				else addNode(state, frame.node);
+				break;
+			}
+		}
+	}
+	return state.documents;
+}
+//#endregion
+exports.CHOMPING_CLIP = CHOMPING_CLIP;
+exports.CHOMPING_KEEP = CHOMPING_KEEP;
+exports.CHOMPING_STRIP = CHOMPING_STRIP;
+exports.COLLECTION_STYLE_BLOCK = COLLECTION_STYLE_BLOCK;
+exports.COLLECTION_STYLE_FLOW = COLLECTION_STYLE_FLOW;
+exports.CORE_SCHEMA = CORE_SCHEMA;
+exports.EVENT_ALIAS = EVENT_ALIAS;
+exports.EVENT_DOCUMENT = EVENT_DOCUMENT;
+exports.EVENT_MAPPING = EVENT_MAPPING;
+exports.EVENT_POP = EVENT_POP;
+exports.EVENT_SCALAR = EVENT_SCALAR;
+exports.EVENT_SEQUENCE = EVENT_SEQUENCE;
+exports.FAILSAFE_SCHEMA = FAILSAFE_SCHEMA;
+exports.JSON_SCHEMA = JSON_SCHEMA;
+exports.MERGE_KEY = MERGE_KEY;
+exports.NOT_RESOLVED = NOT_RESOLVED;
+exports.SCALAR_STYLE_DOUBLE_QUOTED = SCALAR_STYLE_DOUBLE_QUOTED;
+exports.SCALAR_STYLE_FOLDED_BLOCK = SCALAR_STYLE_FOLDED_BLOCK;
+exports.SCALAR_STYLE_LITERAL_BLOCK = SCALAR_STYLE_LITERAL_BLOCK;
+exports.SCALAR_STYLE_PLAIN = SCALAR_STYLE_PLAIN;
+exports.SCALAR_STYLE_SINGLE_QUOTED = SCALAR_STYLE_SINGLE_QUOTED;
+exports.Schema = Schema;
+exports.Style = Style;
+exports.VISIT_BREAK = VISIT_BREAK;
+exports.VISIT_SKIP = VISIT_SKIP;
+exports.YAML11_SCHEMA = YAML11_SCHEMA;
+exports.YAMLException = YAMLException;
+exports.binaryTag = binaryTag;
+exports.boolCoreTag = boolCoreTag;
+exports.boolJsonTag = boolJsonTag;
+exports.boolYaml11Tag = boolYaml11Tag;
+exports.constructFromEvents = constructFromEvents;
+exports.defineMappingTag = defineMappingTag;
+exports.defineScalarTag = defineScalarTag;
+exports.defineSequenceTag = defineSequenceTag;
+exports.dump = dump;
+exports.eventsToAst = eventsToAst;
+exports.floatCoreTag = floatCoreTag;
+exports.floatJsonTag = floatJsonTag;
+exports.floatYaml11Tag = floatYaml11Tag;
+exports.getScalarValue = getScalarValue;
+exports.intCoreTag = intCoreTag;
+exports.intJsonTag = intJsonTag;
+exports.intYaml11Tag = intYaml11Tag;
+exports.jsToAst = jsToAst;
+exports.legacyMapTag = legacyMapTag;
+exports.load = load;
+exports.loadAll = loadAll;
+exports.mapTag = mapTag;
+exports.mergeTag = mergeTag;
+exports.nullCoreTag = nullCoreTag;
+exports.nullJsonTag = nullJsonTag;
+exports.nullYaml11Tag = nullYaml11Tag;
+exports.omapTag = omapTag;
+exports.pairsTag = pairsTag;
+exports.parseEvents = parseEvents;
+exports.present = present;
+exports.realMapTag = realMapTag;
+exports.seqTag = seqTag;
+exports.setTag = setTag;
+exports.strTag = strTag;
+exports.timestampTag = timestampTag;
+exports.visit = visit;
+
+//# sourceMappingURL=js-yaml.cjs.js.map

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/dist/js-yaml.d.ts
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/dist/js-yaml.d.ts
@@ -1,0 +1,382 @@
+declare const NOT_RESOLVED: unique symbol;
+declare const MERGE_KEY: unique symbol;
+type ScalarRepresent = (data: any) => string;
+type SequenceRepresent = (data: any) => ArrayLike<unknown>;
+type MappingRepresent = (data: any) => Map<unknown, unknown>;
+type IdentifyFn = (data: any) => boolean;
+type RepresentTagNameFn = (data: any) => string;
+interface ScalarTagDefinition<Result = unknown> {
+    tagName: string;
+    nodeKind: 'scalar';
+    implicit: boolean;
+    matchByTagPrefix: boolean;
+    implicitFirstChars: readonly string[] | null;
+    resolve: (source: string, isExplicit: boolean, tagName: string) => Result | typeof NOT_RESOLVED;
+    identify: IdentifyFn | null;
+    represent: ScalarRepresent;
+    representTagName: RepresentTagNameFn | null;
+}
+interface SequenceTagDefinition<Carrier = unknown, Result = Carrier> {
+    tagName: string;
+    nodeKind: 'sequence';
+    implicit: false;
+    matchByTagPrefix: boolean;
+    create: (tagName: string) => Carrier;
+    addItem: (carrier: Carrier, item: unknown, index: number) => void | string;
+    finalize: (carrier: Carrier) => Result;
+    carrierIsResult: boolean;
+    identify: IdentifyFn | null;
+    represent: SequenceRepresent;
+    representTagName: RepresentTagNameFn | null;
+}
+interface MappingTagDefinition<Carrier = unknown, Result = Carrier> {
+    tagName: string;
+    nodeKind: 'mapping';
+    implicit: false;
+    matchByTagPrefix: boolean;
+    create: (tagName: string) => Carrier;
+    addPair: (carrier: Carrier, key: unknown, value: unknown) => string;
+    has: (carrier: Carrier, key: unknown) => boolean;
+    keys: (result: Result) => Iterable<unknown>;
+    get: (result: Result, key: unknown) => unknown;
+    finalize: (carrier: Carrier) => Result;
+    carrierIsResult: boolean;
+    identify: IdentifyFn | null;
+    represent: MappingRepresent;
+    representTagName: RepresentTagNameFn | null;
+}
+type TagDefinition = ScalarTagDefinition<any> | SequenceTagDefinition<any, any> | MappingTagDefinition<any, any>;
+interface ScalarTagOptions<Result> {
+    implicit?: boolean;
+    matchByTagPrefix?: boolean;
+    implicitFirstChars?: readonly string[] | null;
+    resolve: ScalarTagDefinition<Result>['resolve'];
+    identify?: ScalarTagDefinition<Result>['identify'];
+    represent?: ScalarTagDefinition<Result>['represent'];
+    representTagName?: ScalarTagDefinition<Result>['representTagName'];
+}
+type RepresentOptions<Container, Canonical, Represent> = {
+    identify?: null;
+    represent?: Represent;
+    representTagName?: RepresentTagNameFn | null;
+} | (Container extends Canonical ? {
+    identify?: IdentifyFn | null;
+    represent?: Represent;
+    representTagName?: RepresentTagNameFn | null;
+} : {
+    identify: IdentifyFn;
+    represent: Represent;
+    representTagName?: RepresentTagNameFn | null;
+});
+type SequenceTagOptions<Carrier, Result = Carrier> = {
+    matchByTagPrefix?: boolean;
+    create: SequenceTagDefinition<Carrier, Result>['create'];
+    addItem: SequenceTagDefinition<Carrier, Result>['addItem'];
+    finalize?: SequenceTagDefinition<Carrier, Result>['finalize'];
+} & RepresentOptions<Result, ArrayLike<unknown>, SequenceRepresent>;
+type MappingTagOptions<Carrier, Result = Carrier> = {
+    matchByTagPrefix?: boolean;
+    create: MappingTagDefinition<Carrier, Result>['create'];
+    addPair: MappingTagDefinition<Carrier, Result>['addPair'];
+    has: MappingTagDefinition<Carrier, Result>['has'];
+    keys: MappingTagDefinition<Carrier, Result>['keys'];
+    get: MappingTagDefinition<Carrier, Result>['get'];
+    finalize?: MappingTagDefinition<Carrier, Result>['finalize'];
+} & RepresentOptions<Result, Map<unknown, unknown>, MappingRepresent>;
+declare function defineScalarTag<Result>(tagName: string, options: ScalarTagOptions<Result>): ScalarTagDefinition<Result>;
+declare function defineSequenceTag<Carrier, Result = Carrier>(tagName: string, options: SequenceTagOptions<Carrier, Result>): SequenceTagDefinition<Carrier, Result>;
+declare function defineMappingTag<Carrier, Result = Carrier>(tagName: string, options: MappingTagOptions<Carrier, Result>): MappingTagDefinition<Carrier, Result>;
+
+interface TagDefinitionMap {
+    scalar: Record<string, ScalarTagDefinition>;
+    sequence: Record<string, SequenceTagDefinition>;
+    mapping: Record<string, MappingTagDefinition>;
+}
+interface TagDefinitionListMap {
+    scalar: ScalarTagDefinition[];
+    sequence: SequenceTagDefinition[];
+    mapping: MappingTagDefinition[];
+}
+declare class Schema {
+    readonly tags: readonly TagDefinition[];
+    readonly implicitScalarTags: readonly ScalarTagDefinition[];
+    readonly implicitScalarByFirstChar: ReadonlyMap<string, readonly ScalarTagDefinition[]>;
+    readonly implicitScalarAnyFirstChar: readonly ScalarTagDefinition[];
+    readonly defaultScalarTag: ScalarTagDefinition;
+    readonly defaultSequenceTag: SequenceTagDefinition | undefined;
+    readonly defaultMappingTag: MappingTagDefinition | undefined;
+    readonly exact: TagDefinitionMap;
+    readonly prefix: TagDefinitionListMap;
+    constructor(tags: readonly TagDefinition[]);
+    withTags(...tags: Array<TagDefinition | readonly TagDefinition[]>): Schema;
+}
+declare const FAILSAFE_SCHEMA: Schema;
+declare const JSON_SCHEMA: Schema;
+declare const CORE_SCHEMA: Schema;
+declare const YAML11_SCHEMA: Schema;
+
+declare const strTag: ScalarTagDefinition<string>;
+
+declare const nullCoreTag: ScalarTagDefinition<null>;
+
+declare const nullJsonTag: ScalarTagDefinition<null>;
+
+declare const nullYaml11Tag: ScalarTagDefinition<null>;
+
+declare const boolCoreTag: ScalarTagDefinition<boolean>;
+
+declare const boolJsonTag: ScalarTagDefinition<boolean>;
+
+declare const boolYaml11Tag: ScalarTagDefinition<boolean>;
+
+declare const intCoreTag: ScalarTagDefinition<number>;
+
+declare const intJsonTag: ScalarTagDefinition<number>;
+
+declare const intYaml11Tag: ScalarTagDefinition<number>;
+
+declare const floatCoreTag: ScalarTagDefinition<number>;
+
+declare const floatJsonTag: ScalarTagDefinition<number>;
+
+declare const floatYaml11Tag: ScalarTagDefinition<number>;
+
+declare const mergeTag: ScalarTagDefinition<typeof MERGE_KEY>;
+
+declare const binaryTag: ScalarTagDefinition<Uint8Array<ArrayBuffer>>;
+
+declare const timestampTag: ScalarTagDefinition<Date>;
+
+declare const seqTag: SequenceTagDefinition<unknown[], unknown[]>;
+
+interface OmapCarrier {
+    list: unknown[];
+    seen: Set<unknown>;
+}
+declare const omapTag: SequenceTagDefinition<OmapCarrier, unknown[]>;
+
+type Pair = [unknown, unknown];
+declare const pairsTag: SequenceTagDefinition<Pair[], Pair[]>;
+
+type StringMapping$1 = Record<string, unknown>;
+declare const mapTag: MappingTagDefinition<StringMapping$1, StringMapping$1>;
+
+type RealMapping = Map<unknown, unknown>;
+declare const realMapTag: MappingTagDefinition<RealMapping, RealMapping>;
+
+type StringMapping = Record<string, unknown>;
+declare const legacyMapTag: MappingTagDefinition<StringMapping, StringMapping>;
+
+declare const setTag: MappingTagDefinition<Set<unknown>, Set<unknown>>;
+
+declare const EVENT_DOCUMENT = 1;
+declare const EVENT_SEQUENCE = 2;
+declare const EVENT_MAPPING = 3;
+declare const EVENT_SCALAR = 4;
+declare const EVENT_ALIAS = 5;
+declare const EVENT_POP = 6;
+declare const SCALAR_STYLE_PLAIN = 1;
+declare const SCALAR_STYLE_SINGLE_QUOTED = 2;
+declare const SCALAR_STYLE_DOUBLE_QUOTED = 3;
+declare const SCALAR_STYLE_LITERAL_BLOCK = 4;
+declare const SCALAR_STYLE_FOLDED_BLOCK = 5;
+type ScalarStyle = typeof SCALAR_STYLE_PLAIN | typeof SCALAR_STYLE_SINGLE_QUOTED | typeof SCALAR_STYLE_DOUBLE_QUOTED | typeof SCALAR_STYLE_LITERAL_BLOCK | typeof SCALAR_STYLE_FOLDED_BLOCK;
+declare const COLLECTION_STYLE_BLOCK = 1;
+declare const COLLECTION_STYLE_FLOW = 2;
+type CollectionStyle = typeof COLLECTION_STYLE_BLOCK | typeof COLLECTION_STYLE_FLOW;
+declare const CHOMPING_CLIP = 1;
+declare const CHOMPING_STRIP = 2;
+declare const CHOMPING_KEEP = 3;
+type Chomping = typeof CHOMPING_CLIP | typeof CHOMPING_STRIP | typeof CHOMPING_KEEP;
+type DocumentDirective = {
+    kind: 'yaml';
+    version: string;
+} | {
+    kind: 'tag';
+    handle: string;
+    prefix: string;
+};
+interface DocumentEvent {
+    type: typeof EVENT_DOCUMENT;
+    explicitStart: boolean;
+    explicitEnd: boolean;
+    directives: DocumentDirective[];
+}
+interface SequenceEvent {
+    type: typeof EVENT_SEQUENCE;
+    start: number;
+    anchorStart: number;
+    anchorEnd: number;
+    tagStart: number;
+    tagEnd: number;
+    style: CollectionStyle;
+}
+interface MappingEvent {
+    type: typeof EVENT_MAPPING;
+    start: number;
+    anchorStart: number;
+    anchorEnd: number;
+    tagStart: number;
+    tagEnd: number;
+    style: CollectionStyle;
+}
+interface ScalarEvent {
+    type: typeof EVENT_SCALAR;
+    valueStart: number;
+    valueEnd: number;
+    anchorStart: number;
+    anchorEnd: number;
+    tagStart: number;
+    tagEnd: number;
+    style: ScalarStyle;
+    chomping: Chomping;
+    indent: number;
+    fast: boolean;
+}
+interface AliasEvent {
+    type: typeof EVENT_ALIAS;
+    anchorStart: number;
+    anchorEnd: number;
+}
+interface PopEvent {
+    type: typeof EVENT_POP;
+}
+type Event = DocumentEvent | SequenceEvent | MappingEvent | ScalarEvent | AliasEvent | PopEvent;
+
+interface ConstructorOptions {
+    source: string;
+    filename?: string;
+    schema?: Schema;
+    json?: boolean;
+    maxTotalMergeKeys?: number;
+    maxAliases?: number;
+}
+declare function constructFromEvents(events: Event[], options: ConstructorOptions): unknown[];
+
+interface ParserOptions {
+    filename?: string;
+    maxDepth?: number;
+}
+declare function parseEvents(input: string, options: ParserOptions): Event[];
+
+interface LoadOptions extends ParserOptions, Omit<ConstructorOptions, 'source'> {
+}
+type LoadAllIterator = (document: unknown) => void;
+declare function loadAll(input: string, options?: LoadOptions): unknown[];
+declare function loadAll(input: string, iterator: null, options?: LoadOptions): unknown[];
+declare function loadAll(input: string, iterator: LoadAllIterator, options?: LoadOptions): void;
+declare function load(input: string, options?: LoadOptions): unknown;
+
+declare class Style {
+    tagged: boolean;
+    flow: boolean;
+    singleQuoted: boolean;
+    doubleQuoted: boolean;
+    literal: boolean;
+    folded: boolean;
+}
+interface NodeBase {
+    tag: string;
+    style: Style;
+    anchor?: string;
+    commentBefore?: string;
+    comment?: string;
+    commentAfter?: string;
+    blankBefore?: number;
+}
+interface ScalarNode extends NodeBase {
+    kind: 'scalar';
+    value: string;
+}
+interface SequenceNode extends NodeBase {
+    kind: 'sequence';
+    items: Node[];
+}
+interface MappingNode extends NodeBase {
+    kind: 'mapping';
+    items: Array<{
+        key: Node;
+        value: Node;
+    }>;
+}
+interface AliasNode extends NodeBase {
+    kind: 'alias';
+    anchor: string;
+}
+type Node = ScalarNode | SequenceNode | MappingNode | AliasNode;
+interface Document {
+    contents: Node | null;
+    explicitStart?: boolean;
+    explicitEnd?: boolean;
+    directives: DocumentDirective[];
+}
+
+interface PresenterOptions {
+    schema: Schema;
+    indent?: number;
+    seqNoIndent?: boolean;
+    seqInlineFirst?: boolean;
+    sortKeys?: boolean | ((a: any, b: any) => number);
+    lineWidth?: number;
+    flowBracketPadding?: boolean;
+    flowSkipCommaSpace?: boolean;
+    flowSkipColonSpace?: boolean;
+    quoteFlowKeys?: boolean;
+    quoteStyle?: 'single' | 'double';
+    forceQuotes?: boolean;
+    tagBeforeAnchor?: boolean;
+}
+declare function present(documents: Document[], options: PresenterOptions): string;
+
+interface DumpOptions extends Omit<PresenterOptions, 'schema'> {
+    schema?: Schema;
+    skipInvalid?: boolean;
+    noRefs?: boolean;
+    flowLevel?: number;
+    transform?: (documents: Document[]) => void;
+}
+declare function dump(input: any, options?: DumpOptions): string;
+
+interface SnippetMark {
+    name?: string | null;
+    buffer: string;
+    position: number;
+    line: number;
+    column: number;
+    snippet?: string | null;
+}
+
+declare class YAMLException extends Error {
+    reason: string;
+    mark?: SnippetMark;
+    constructor(reason: string, mark?: SnippetMark);
+    toString(compact?: boolean): string;
+}
+
+declare function getScalarValue(input: string, scalar: ScalarEvent): string;
+
+interface FromEventsOptions {
+    source: string;
+    schema: Schema;
+}
+declare function eventsToAst(events: Event[], options: FromEventsOptions): Document[];
+
+interface FromJsOptions {
+    noRefs?: boolean;
+    skipInvalid?: boolean;
+}
+declare function jsToAst(input: unknown, schema: Schema, options?: FromJsOptions): Document[];
+
+declare const VISIT_BREAK: unique symbol;
+declare const VISIT_SKIP: unique symbol;
+type VisitControl = typeof VISIT_BREAK | typeof VISIT_SKIP | undefined | void;
+interface VisitContext {
+    depth: number;
+    parent: Node | null;
+    isKey: boolean;
+}
+type Visitor = (node: Node, ctx: VisitContext) => VisitControl;
+declare function visit(documents: Document[], visitor: Visitor): void;
+
+export { CHOMPING_CLIP, CHOMPING_KEEP, CHOMPING_STRIP, COLLECTION_STYLE_BLOCK, COLLECTION_STYLE_FLOW, CORE_SCHEMA, EVENT_ALIAS, EVENT_DOCUMENT, EVENT_MAPPING, EVENT_POP, EVENT_SCALAR, EVENT_SEQUENCE, FAILSAFE_SCHEMA, JSON_SCHEMA, MERGE_KEY, NOT_RESOLVED, SCALAR_STYLE_DOUBLE_QUOTED, SCALAR_STYLE_FOLDED_BLOCK, SCALAR_STYLE_LITERAL_BLOCK, SCALAR_STYLE_PLAIN, SCALAR_STYLE_SINGLE_QUOTED, Schema, Style, VISIT_BREAK, VISIT_SKIP, YAML11_SCHEMA, YAMLException, binaryTag, boolCoreTag, boolJsonTag, boolYaml11Tag, constructFromEvents, defineMappingTag, defineScalarTag, defineSequenceTag, dump, eventsToAst, floatCoreTag, floatJsonTag, floatYaml11Tag, getScalarValue, intCoreTag, intJsonTag, intYaml11Tag, jsToAst, legacyMapTag, load, loadAll, mapTag, mergeTag, nullCoreTag, nullJsonTag, nullYaml11Tag, omapTag, pairsTag, parseEvents, present, realMapTag, seqTag, setTag, strTag, timestampTag, visit };
+export type { AliasEvent, AliasNode, ConstructorOptions, Document, DocumentDirective, DocumentEvent, DumpOptions, Event, FromEventsOptions, FromJsOptions, LoadOptions, MappingEvent, MappingNode, MappingTagDefinition, MappingTagOptions, Node, NodeBase, ParserOptions, PopEvent, PresenterOptions, ScalarEvent, ScalarNode, ScalarTagDefinition, ScalarTagOptions, SequenceEvent, SequenceNode, SequenceTagDefinition, SequenceTagOptions, TagDefinition, VisitContext, Visitor };

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/dist/js-yaml.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/dist/js-yaml.mjs
@@ -1,0 +1,3159 @@
+/*! js-yaml 5.2.3 https://github.com/nodeca/js-yaml @license MIT */
+//#region src/tag.ts
+var NOT_RESOLVED = Symbol("NOT_RESOLVED");
+var MERGE_KEY = Symbol("MERGE_KEY");
+function defineScalarTag(tagName, options) {
+	return {
+		tagName,
+		nodeKind: "scalar",
+		implicit: options.implicit ?? false,
+		matchByTagPrefix: options.matchByTagPrefix ?? false,
+		implicitFirstChars: options.implicitFirstChars ?? null,
+		resolve: options.resolve,
+		identify: options.identify ?? null,
+		represent: options.represent ?? ((data) => String(data)),
+		representTagName: options.representTagName ?? null
+	};
+}
+function defineSequenceTag(tagName, options) {
+	const carrierIsResult = options.finalize === void 0;
+	return {
+		tagName,
+		nodeKind: "sequence",
+		implicit: false,
+		matchByTagPrefix: options.matchByTagPrefix ?? false,
+		create: options.create,
+		addItem: options.addItem,
+		finalize: options.finalize ?? ((carrier) => carrier),
+		carrierIsResult,
+		identify: options.identify ?? null,
+		represent: options.represent ?? ((data) => data),
+		representTagName: options.representTagName ?? null
+	};
+}
+function defineMappingTag(tagName, options) {
+	const carrierIsResult = options.finalize === void 0;
+	return {
+		tagName,
+		nodeKind: "mapping",
+		implicit: false,
+		matchByTagPrefix: options.matchByTagPrefix ?? false,
+		create: options.create,
+		addPair: options.addPair,
+		has: options.has,
+		keys: options.keys,
+		get: options.get,
+		finalize: options.finalize ?? ((carrier) => carrier),
+		carrierIsResult,
+		identify: options.identify ?? null,
+		represent: options.represent ?? ((data) => data),
+		representTagName: options.representTagName ?? null
+	};
+}
+//#endregion
+//#region src/tag/scalar/str.ts
+var strTag = defineScalarTag("tag:yaml.org,2002:str", {
+	resolve: (source) => source,
+	identify: (data) => typeof data === "string"
+});
+//#endregion
+//#region src/tag/scalar/null_core.ts
+var NULL_VALUES$1 = [
+	"",
+	"~",
+	"null",
+	"Null",
+	"NULL"
+];
+var nullCoreTag = defineScalarTag("tag:yaml.org,2002:null", {
+	implicit: true,
+	implicitFirstChars: [
+		"",
+		"~",
+		"n",
+		"N"
+	],
+	resolve: (source) => {
+		if (NULL_VALUES$1.indexOf(source) !== -1) return null;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => object === null,
+	represent: () => "null"
+});
+//#endregion
+//#region src/tag/scalar/null_json.ts
+var nullJsonTag = defineScalarTag("tag:yaml.org,2002:null", {
+	implicit: true,
+	implicitFirstChars: ["n"],
+	resolve: (source, isExplicit) => {
+		if (source === "null" || isExplicit && source === "") return null;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => object === null,
+	represent: () => "null"
+});
+//#endregion
+//#region src/tag/scalar/null_yaml11.ts
+var NULL_VALUES = [
+	"",
+	"~",
+	"null",
+	"Null",
+	"NULL"
+];
+var nullYaml11Tag = defineScalarTag("tag:yaml.org,2002:null", {
+	implicit: true,
+	implicitFirstChars: [
+		"",
+		"~",
+		"n",
+		"N"
+	],
+	resolve: (source) => {
+		if (NULL_VALUES.indexOf(source) !== -1) return null;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => object === null,
+	represent: () => "null"
+});
+//#endregion
+//#region src/tag/scalar/bool_core.ts
+var TRUE_VALUES$2 = [
+	"true",
+	"True",
+	"TRUE"
+];
+var FALSE_VALUES$2 = [
+	"false",
+	"False",
+	"FALSE"
+];
+var boolCoreTag = defineScalarTag("tag:yaml.org,2002:bool", {
+	implicit: true,
+	implicitFirstChars: [
+		"t",
+		"T",
+		"f",
+		"F"
+	],
+	resolve: (source) => {
+		if (TRUE_VALUES$2.indexOf(source) !== -1) return true;
+		if (FALSE_VALUES$2.indexOf(source) !== -1) return false;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => Object.prototype.toString.call(object) === "[object Boolean]",
+	represent: (object) => object ? "true" : "false"
+});
+//#endregion
+//#region src/tag/scalar/bool_json.ts
+var TRUE_VALUES$1 = ["true"];
+var FALSE_VALUES$1 = ["false"];
+var boolJsonTag = defineScalarTag("tag:yaml.org,2002:bool", {
+	implicit: true,
+	implicitFirstChars: ["t", "f"],
+	resolve: (source) => {
+		if (TRUE_VALUES$1.indexOf(source) !== -1) return true;
+		if (FALSE_VALUES$1.indexOf(source) !== -1) return false;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => Object.prototype.toString.call(object) === "[object Boolean]",
+	represent: (object) => object ? "true" : "false"
+});
+//#endregion
+//#region src/tag/scalar/bool_yaml11.ts
+var TRUE_VALUES = [
+	"true",
+	"True",
+	"TRUE",
+	"y",
+	"Y",
+	"yes",
+	"Yes",
+	"YES",
+	"on",
+	"On",
+	"ON"
+];
+var FALSE_VALUES = [
+	"false",
+	"False",
+	"FALSE",
+	"n",
+	"N",
+	"no",
+	"No",
+	"NO",
+	"off",
+	"Off",
+	"OFF"
+];
+var boolYaml11Tag = defineScalarTag("tag:yaml.org,2002:bool", {
+	implicit: true,
+	implicitFirstChars: [
+		"y",
+		"Y",
+		"n",
+		"N",
+		"t",
+		"T",
+		"f",
+		"F",
+		"o",
+		"O"
+	],
+	resolve: (source) => {
+		if (TRUE_VALUES.indexOf(source) !== -1) return true;
+		if (FALSE_VALUES.indexOf(source) !== -1) return false;
+		return NOT_RESOLVED;
+	},
+	identify: (object) => Object.prototype.toString.call(object) === "[object Boolean]",
+	represent: (object) => object ? "true" : "false"
+});
+//#endregion
+//#region src/tag/scalar/int_core.ts
+var YAML_INTEGER_IMPLICIT_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:0o[0-7]+|0x[0-9a-fA-F]+|[-+]?[0-9]+)$");
+var YAML_INTEGER_EXPLICIT_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:[-+]?0b[0-1]+|[-+]?0o[0-7]+|[-+]?0x[0-9a-fA-F]+|[-+]?[0-9]+)$");
+function parseYamlInteger$2(source) {
+	let value = source;
+	let sign = 1;
+	if (value[0] === "-" || value[0] === "+") {
+		if (value[0] === "-") sign = -1;
+		value = value.slice(1);
+	}
+	if (value.startsWith("0b")) return sign * parseInt(value.slice(2), 2);
+	if (value.startsWith("0o")) return sign * parseInt(value.slice(2), 8);
+	if (value.startsWith("0x")) return sign * parseInt(value.slice(2), 16);
+	return sign * parseInt(value, 10);
+}
+function resolveYamlInteger$2(source, isExplicit) {
+	if (isExplicit) {
+		if (!YAML_INTEGER_EXPLICIT_PATTERN$1.test(source)) return NOT_RESOLVED;
+	} else if (!YAML_INTEGER_IMPLICIT_PATTERN$1.test(source)) return NOT_RESOLVED;
+	const result = parseYamlInteger$2(source);
+	return Number.isFinite(result) ? result : NOT_RESOLVED;
+}
+var intCoreTag = defineScalarTag("tag:yaml.org,2002:int", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		..."0123456789"
+	],
+	resolve: resolveYamlInteger$2,
+	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	represent: (object) => object.toString(10)
+});
+//#endregion
+//#region src/tag/scalar/int_json.ts
+var YAML_INTEGER_IMPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^-?(?:0|[1-9][0-9]*)$");
+var YAML_INTEGER_EXPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?0b[0-1]+|[-+]?0o[0-7]+|[-+]?0x[0-9a-fA-F]+|[-+]?[0-9]+)$");
+function parseYamlInteger$1(source) {
+	let value = source;
+	let sign = 1;
+	if (value[0] === "-" || value[0] === "+") {
+		if (value[0] === "-") sign = -1;
+		value = value.slice(1);
+	}
+	if (value.startsWith("0b")) return sign * parseInt(value.slice(2), 2);
+	if (value.startsWith("0o")) return sign * parseInt(value.slice(2), 8);
+	if (value.startsWith("0x")) return sign * parseInt(value.slice(2), 16);
+	return sign * parseInt(value, 10);
+}
+function resolveYamlInteger$1(source, isExplicit) {
+	if (isExplicit) {
+		if (!YAML_INTEGER_EXPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+	} else if (!YAML_INTEGER_IMPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+	const result = parseYamlInteger$1(source);
+	return Number.isFinite(result) ? result : NOT_RESOLVED;
+}
+var intJsonTag = defineScalarTag("tag:yaml.org,2002:int", {
+	implicit: true,
+	implicitFirstChars: ["-", ..."0123456789"],
+	resolve: resolveYamlInteger$1,
+	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	represent: (object) => object.toString(10)
+});
+//#endregion
+//#region src/tag/scalar/int_yaml11.ts
+var YAML_INTEGER_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?0x[0-9a-fA-F_]+|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+|[-+]?(?:0|[1-9][0-9_]*))$");
+function parseYamlInteger(source) {
+	let value = source.replace(/_/g, "");
+	let sign = 1;
+	if (value[0] === "-" || value[0] === "+") {
+		if (value[0] === "-") sign = -1;
+		value = value.slice(1);
+	}
+	if (value.startsWith("0b")) return sign * parseInt(value.slice(2), 2);
+	if (value.startsWith("0x")) return sign * parseInt(value.slice(2), 16);
+	if (value.includes(":")) {
+		let result = 0;
+		for (const part of value.split(":")) result = result * 60 + Number(part);
+		return sign * result;
+	}
+	if (value !== "0" && value[0] === "0") return sign * parseInt(value, 8);
+	return sign * parseInt(value, 10);
+}
+function resolveYamlInteger(source) {
+	if (!YAML_INTEGER_PATTERN.test(source)) return NOT_RESOLVED;
+	const result = parseYamlInteger(source);
+	return Number.isFinite(result) ? result : NOT_RESOLVED;
+}
+var intYaml11Tag = defineScalarTag("tag:yaml.org,2002:int", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		..."0123456789"
+	],
+	resolve: resolveYamlInteger,
+	identify: (object) => Number.isInteger(object) && !Object.is(object, -0) && object.toString(10).indexOf("e") < 0,
+	represent: (object) => object.toString(10)
+});
+//#endregion
+//#region src/tag/scalar/float_core.ts
+var YAML_FLOAT_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:[-+]?[0-9]+(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?|[-+]?\\.[0-9]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+var YAML_FLOAT_SPECIAL_PATTERN$1 = /* @__PURE__ */ new RegExp("^(?:[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+function resolveYamlFloat$2(source) {
+	if (!YAML_FLOAT_PATTERN$1.test(source)) return NOT_RESOLVED;
+	let value = source.toLowerCase();
+	const sign = value[0] === "-" ? -1 : 1;
+	if ("+-".includes(value[0])) value = value.slice(1);
+	if (value === ".inf") return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+	if (value === ".nan") return NaN;
+	const result = sign * parseFloat(value);
+	if (Number.isFinite(result) || YAML_FLOAT_SPECIAL_PATTERN$1.test(source)) return result;
+	return NOT_RESOLVED;
+}
+function representYamlFloat$2(object) {
+	if (isNaN(object)) return ".nan";
+	if (object === Number.POSITIVE_INFINITY) return ".inf";
+	if (object === Number.NEGATIVE_INFINITY) return "-.inf";
+	if (Object.is(object, -0)) return "-0.0";
+	const result = object.toString(10);
+	return /^[-+]?[0-9]+e/.test(result) ? result.replace("e", ".e") : result;
+}
+var floatCoreTag = defineScalarTag("tag:yaml.org,2002:float", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		".",
+		..."0123456789"
+	],
+	resolve: resolveYamlFloat$2,
+	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	represent: representYamlFloat$2
+});
+//#endregion
+//#region src/tag/scalar/float_json.ts
+var YAML_FLOAT_IMPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^-?(?:0|[1-9][0-9]*)(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?$");
+var YAML_FLOAT_EXPLICIT_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?[0-9]+(?:\\.[0-9]*)?(?:[eE][-+]?[0-9]+)?|[-+]?\\.[0-9]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+function resolveYamlFloat$1(source, isExplicit) {
+	if (isExplicit) {
+		if (!YAML_FLOAT_EXPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+		let value = source.toLowerCase();
+		const sign = value[0] === "-" ? -1 : 1;
+		if ("+-".includes(value[0])) value = value.slice(1);
+		if (value === ".inf") return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+		if (value === ".nan") return NaN;
+		const result = sign * parseFloat(value);
+		return Number.isFinite(result) ? result : NOT_RESOLVED;
+	}
+	if (!YAML_FLOAT_IMPLICIT_PATTERN.test(source)) return NOT_RESOLVED;
+	const result = Number(source);
+	if (Number.isFinite(result)) return result;
+	return NOT_RESOLVED;
+}
+function representYamlFloat$1(object) {
+	if (isNaN(object)) return ".nan";
+	if (object === Number.POSITIVE_INFINITY) return ".inf";
+	if (object === Number.NEGATIVE_INFINITY) return "-.inf";
+	if (Object.is(object, -0)) return "-0.0";
+	const result = object.toString(10);
+	return /^[-+]?[0-9]+e/.test(result) ? result.replace("e", ".e") : result;
+}
+var floatJsonTag = defineScalarTag("tag:yaml.org,2002:float", {
+	implicit: true,
+	implicitFirstChars: ["-", ..."0123456789"],
+	resolve: resolveYamlFloat$1,
+	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	represent: representYamlFloat$1
+});
+//#endregion
+//#region src/tag/scalar/float_yaml11.ts
+var YAML_FLOAT_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?(?:(?:[0-9][0-9_]*)?\\.[0-9_]*)(?:[eE][-+][0-9]+)?|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\\.[0-9_]*|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+var YAML_FLOAT_SPECIAL_PATTERN = /* @__PURE__ */ new RegExp("^(?:[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");
+function resolveYamlFloat(source) {
+	if (!YAML_FLOAT_PATTERN.test(source)) return NOT_RESOLVED;
+	let value = source.toLowerCase().replace(/_/g, "");
+	const sign = value[0] === "-" ? -1 : 1;
+	if ("+-".includes(value[0])) value = value.slice(1);
+	if (value === ".inf") return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+	if (value === ".nan") return NaN;
+	let result = 0;
+	if (value.includes(":")) {
+		for (const part of value.split(":")) result = result * 60 + Number(part);
+		result *= sign;
+	} else result = sign * parseFloat(value);
+	if (Number.isFinite(result) || YAML_FLOAT_SPECIAL_PATTERN.test(source)) return result;
+	return NOT_RESOLVED;
+}
+function representYamlFloat(object) {
+	if (isNaN(object)) return ".nan";
+	if (object === Number.POSITIVE_INFINITY) return ".inf";
+	if (object === Number.NEGATIVE_INFINITY) return "-.inf";
+	if (Object.is(object, -0)) return "-0.0";
+	const result = object.toString(10);
+	return /^[-+]?[0-9]+e/.test(result) ? result.replace("e", ".e") : result;
+}
+var floatYaml11Tag = defineScalarTag("tag:yaml.org,2002:float", {
+	implicit: true,
+	implicitFirstChars: [
+		"-",
+		"+",
+		".",
+		..."0123456789"
+	],
+	resolve: resolveYamlFloat,
+	identify: (object) => typeof object === "number" && (!Number.isInteger(object) || Object.is(object, -0) || object.toString(10).indexOf("e") >= 0),
+	represent: representYamlFloat
+});
+//#endregion
+//#region src/tag/scalar/merge.ts
+var mergeTag = defineScalarTag("tag:yaml.org,2002:merge", {
+	implicit: true,
+	implicitFirstChars: ["<"],
+	resolve: (source, isExplicit) => {
+		if (source === "<<" || isExplicit && source === "") return MERGE_KEY;
+		return NOT_RESOLVED;
+	}
+});
+//#endregion
+//#region src/tag/scalar/binary.ts
+var BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/;
+function resolveYamlBinary(source) {
+	const input = source.replace(/\s/g, "");
+	if (input.length % 4 !== 0 || !BASE64_PATTERN.test(input)) return NOT_RESOLVED;
+	const binary = atob(input);
+	const result = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index++) result[index] = binary.charCodeAt(index);
+	return result;
+}
+function representYamlBinary(object) {
+	let binary = "";
+	for (let index = 0; index < object.length; index++) binary += String.fromCharCode(object[index]);
+	return btoa(binary);
+}
+var binaryTag = defineScalarTag("tag:yaml.org,2002:binary", {
+	resolve: resolveYamlBinary,
+	identify: (object) => Object.prototype.toString.call(object) === "[object Uint8Array]",
+	represent: representYamlBinary
+});
+//#endregion
+//#region src/tag/scalar/timestamp.ts
+var YAML_DATE_REGEXP = /* @__PURE__ */ new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$");
+var YAML_TIMESTAMP_REGEXP = /* @__PURE__ */ new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$");
+function makeUtcDate(year, month, day, hour = 0, minute = 0, second = 0, fraction = 0) {
+	const date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+	date.setUTCFullYear(year, month, day);
+	return date;
+}
+function resolveYamlTimestamp(source) {
+	let match = YAML_DATE_REGEXP.exec(source);
+	if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(source);
+	if (match === null) return NOT_RESOLVED;
+	const year = +match[1];
+	const month = +match[2] - 1;
+	const day = +match[3];
+	if (!match[4]) {
+		const date = makeUtcDate(year, month, day);
+		if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) return NOT_RESOLVED;
+		return date;
+	}
+	const hour = +match[4];
+	const minute = +match[5];
+	const second = +match[6];
+	let fraction = 0;
+	if (hour > 23 || minute > 59 || second > 59) return NOT_RESOLVED;
+	if (match[7]) {
+		let value = match[7].slice(0, 3);
+		while (value.length < 3) value += "0";
+		fraction = +value;
+	}
+	const date = makeUtcDate(year, month, day, hour, minute, second, fraction);
+	if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) return NOT_RESOLVED;
+	if (match[9]) {
+		const offsetHour = +match[10];
+		const offsetMinute = +(match[11] || 0);
+		if (offsetHour > 23 || offsetMinute > 59) return NOT_RESOLVED;
+		const offset = (offsetHour * 60 + offsetMinute) * 6e4;
+		date.setTime(date.getTime() - (match[9] === "-" ? -offset : offset));
+	}
+	return date;
+}
+var timestampTag = defineScalarTag("tag:yaml.org,2002:timestamp", {
+	implicit: true,
+	implicitFirstChars: [..."0123456789"],
+	resolve: resolveYamlTimestamp,
+	identify: (object) => object instanceof Date,
+	represent: (object) => object.toISOString()
+});
+//#endregion
+//#region src/tag/sequence/seq.ts
+var seqTag = defineSequenceTag("tag:yaml.org,2002:seq", {
+	create: () => [],
+	addItem: (container, item) => {
+		container.push(item);
+	},
+	identify: Array.isArray
+});
+//#endregion
+//#region src/common/object.ts
+function isPlainObject(data) {
+	if (data === null || typeof data !== "object" || Array.isArray(data)) return false;
+	const prototype = Object.getPrototypeOf(data);
+	return prototype === null || prototype === Object.prototype;
+}
+function pick(object, keys) {
+	const result = {};
+	for (const key of keys) if (object[key] !== void 0) result[key] = object[key];
+	return result;
+}
+//#endregion
+//#region src/tag/sequence/omap.ts
+var omapTag = defineSequenceTag("tag:yaml.org,2002:omap", {
+	create: () => ({
+		list: [],
+		seen: /* @__PURE__ */ new Set()
+	}),
+	addItem: (carrier, item) => {
+		let key;
+		if (item instanceof Map) {
+			if (item.size !== 1) return "cannot resolve an ordered map item";
+			key = item.keys().next().value;
+		} else if (isPlainObject(item)) {
+			const itemKeys = Object.keys(item);
+			if (itemKeys.length !== 1) return "cannot resolve an ordered map item";
+			key = itemKeys[0];
+		} else return "cannot resolve an ordered map item";
+		if (carrier.seen.has(key)) return "duplicate key in ordered map";
+		carrier.seen.add(key);
+		carrier.list.push(item);
+		return "";
+	},
+	finalize: (carrier) => carrier.list
+});
+//#endregion
+//#region src/tag/sequence/pairs.ts
+var pairsTag = defineSequenceTag("tag:yaml.org,2002:pairs", {
+	create: () => [],
+	addItem: (container, item) => {
+		if (item instanceof Map) {
+			if (item.size !== 1) return "cannot resolve a pairs item";
+			container.push(item.entries().next().value);
+			return "";
+		}
+		if (Object.prototype.toString.call(item) !== "[object Object]") return "cannot resolve a pairs item";
+		const object = item;
+		const keys = Object.keys(object);
+		if (keys.length !== 1) return "cannot resolve a pairs item";
+		container.push([keys[0], object[keys[0]]]);
+		return "";
+	}
+});
+//#endregion
+//#region src/tag/mapping/map.ts
+var mapTag = defineMappingTag("tag:yaml.org,2002:map", {
+	create: () => ({}),
+	identify: isPlainObject,
+	represent: (o) => {
+		const map = /* @__PURE__ */ new Map();
+		for (const key of Object.keys(o)) map.set(key, o[key]);
+		return map;
+	},
+	addPair: (container, key, value) => {
+		if (key !== null && typeof key === "object") return "object-based map does not support complex keys";
+		const normalizedKey = String(key);
+		if (normalizedKey === "__proto__") Object.defineProperty(container, normalizedKey, {
+			value,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		});
+		else container[normalizedKey] = value;
+		return "";
+	},
+	has: (container, key) => {
+		if (key !== null && typeof key === "object") return false;
+		return Object.prototype.hasOwnProperty.call(container, String(key));
+	},
+	keys: (container) => Object.keys(container),
+	get: (container, key) => {
+		const normalizedKey = String(key);
+		if (!Object.prototype.hasOwnProperty.call(container, normalizedKey)) return null;
+		return container[normalizedKey];
+	}
+});
+//#endregion
+//#region src/tag/mapping/set.ts
+var setTag = defineMappingTag("tag:yaml.org,2002:set", {
+	create: () => /* @__PURE__ */ new Set(),
+	identify: (data) => data instanceof Set,
+	represent: (data) => {
+		const map = /* @__PURE__ */ new Map();
+		for (const key of data) map.set(key, null);
+		return map;
+	},
+	addPair: (container, key, value) => {
+		if (value !== null) return "cannot resolve a set item";
+		container.add(key);
+		return "";
+	},
+	has: (container, key) => container.has(key),
+	keys: (container) => container.keys(),
+	get: () => null
+});
+//#endregion
+//#region src/schema.ts
+function createTagDefinitionMap() {
+	return {
+		scalar: Object.create(null),
+		sequence: Object.create(null),
+		mapping: Object.create(null)
+	};
+}
+function createTagDefinitionListMap() {
+	return {
+		scalar: [],
+		sequence: [],
+		mapping: []
+	};
+}
+function compileTags(tags) {
+	const result = [];
+	for (const tag of tags) {
+		let index = result.length;
+		for (let previousIndex = 0; previousIndex < result.length; previousIndex++) {
+			const previous = result[previousIndex];
+			if (previous.nodeKind === tag.nodeKind && previous.tagName === tag.tagName && previous.matchByTagPrefix === tag.matchByTagPrefix) {
+				index = previousIndex;
+				break;
+			}
+		}
+		result[index] = tag;
+	}
+	return result;
+}
+var Schema = class Schema {
+	tags;
+	implicitScalarTags;
+	implicitScalarByFirstChar;
+	implicitScalarAnyFirstChar;
+	defaultScalarTag;
+	defaultSequenceTag;
+	defaultMappingTag;
+	exact;
+	prefix;
+	constructor(tags) {
+		const compiledTags = compileTags(tags);
+		const implicitScalarTags = [];
+		const exact = createTagDefinitionMap();
+		const prefix = createTagDefinitionListMap();
+		for (const tag of compiledTags) {
+			if (tag.nodeKind === "scalar" && tag.implicit) {
+				if (tag.matchByTagPrefix) throw new Error("Implicit scalar tags cannot match by tag prefix");
+				implicitScalarTags.push(tag);
+			}
+			switch (tag.nodeKind) {
+				case "scalar":
+					if (tag.matchByTagPrefix) prefix.scalar.push(tag);
+					else exact.scalar[tag.tagName] = tag;
+					break;
+				case "sequence":
+					if (tag.matchByTagPrefix) prefix.sequence.push(tag);
+					else exact.sequence[tag.tagName] = tag;
+					break;
+				case "mapping":
+					if (tag.matchByTagPrefix) prefix.mapping.push(tag);
+					else exact.mapping[tag.tagName] = tag;
+					break;
+			}
+		}
+		const implicitScalarAnyFirstChar = implicitScalarTags.filter((tag) => tag.implicitFirstChars === null);
+		const keys = /* @__PURE__ */ new Set();
+		for (const tag of implicitScalarTags) if (tag.implicitFirstChars !== null) for (const key of tag.implicitFirstChars) keys.add(key);
+		const implicitScalarByFirstChar = /* @__PURE__ */ new Map();
+		for (const key of keys) implicitScalarByFirstChar.set(key, implicitScalarTags.filter((tag) => tag.implicitFirstChars === null || tag.implicitFirstChars.indexOf(key) !== -1));
+		const defaultScalarTag = exact.scalar["tag:yaml.org,2002:str"];
+		if (!defaultScalarTag) throw new Error("schema does not define the default scalar tag (tag:yaml.org,2002:str)");
+		this.tags = compiledTags;
+		this.implicitScalarTags = implicitScalarTags;
+		this.implicitScalarByFirstChar = implicitScalarByFirstChar;
+		this.implicitScalarAnyFirstChar = implicitScalarAnyFirstChar;
+		this.defaultScalarTag = defaultScalarTag;
+		this.defaultSequenceTag = exact.sequence["tag:yaml.org,2002:seq"];
+		this.defaultMappingTag = exact.mapping["tag:yaml.org,2002:map"];
+		this.exact = exact;
+		this.prefix = prefix;
+	}
+	withTags(...tags) {
+		let flatTags = [];
+		for (const tag of tags) flatTags = flatTags.concat(tag);
+		return new Schema([...this.tags, ...flatTags]);
+	}
+};
+var FAILSAFE_SCHEMA = new Schema([
+	strTag,
+	seqTag,
+	mapTag
+]);
+var JSON_SCHEMA = new Schema([
+	...FAILSAFE_SCHEMA.tags,
+	nullJsonTag,
+	boolJsonTag,
+	intJsonTag,
+	floatJsonTag
+]);
+var CORE_SCHEMA = new Schema([
+	...FAILSAFE_SCHEMA.tags,
+	nullCoreTag,
+	boolCoreTag,
+	intCoreTag,
+	floatCoreTag
+]);
+var YAML11_SCHEMA = new Schema([
+	...FAILSAFE_SCHEMA.tags,
+	nullYaml11Tag,
+	boolYaml11Tag,
+	intYaml11Tag,
+	floatYaml11Tag,
+	timestampTag,
+	mergeTag,
+	binaryTag,
+	omapTag,
+	pairsTag,
+	setTag
+]);
+//#endregion
+//#region src/tag/mapping/real_map.ts
+var realMapTag = defineMappingTag("tag:yaml.org,2002:map", {
+	create: () => /* @__PURE__ */ new Map(),
+	addPair: (container, key, value) => {
+		container.set(key, value);
+		return "";
+	},
+	has: (container, key) => container.has(key),
+	keys: (container) => container.keys(),
+	get: (container, key) => container.get(key),
+	identify: (data) => data instanceof Map || isPlainObject(data),
+	represent: (data) => {
+		if (data instanceof Map) return data;
+		const map = /* @__PURE__ */ new Map();
+		const obj = data;
+		for (const key of Object.keys(obj)) map.set(key, obj[key]);
+		return map;
+	}
+});
+//#endregion
+//#region src/tag/mapping/legacy_map.ts
+function normalizeKey(key) {
+	if (Array.isArray(key)) {
+		const array = Array.prototype.slice.call(key);
+		for (let index = 0; index < array.length; index++) {
+			if (Array.isArray(array[index])) return null;
+			if (typeof array[index] === "object" && Object.prototype.toString.call(array[index]) === "[object Object]") array[index] = "[object Object]";
+		}
+		return String(array);
+	}
+	if (typeof key === "object" && Object.prototype.toString.call(key) === "[object Object]") return "[object Object]";
+	return String(key);
+}
+var legacyMapTag = defineMappingTag("tag:yaml.org,2002:map", {
+	create: () => ({}),
+	identify: isPlainObject,
+	represent: (o) => {
+		const map = /* @__PURE__ */ new Map();
+		for (const key of Object.keys(o)) map.set(key, o[key]);
+		return map;
+	},
+	addPair: (container, key, value) => {
+		const normalizedKey = normalizeKey(key);
+		if (normalizedKey === null) return "nested arrays are not supported inside keys";
+		if (normalizedKey === "__proto__") Object.defineProperty(container, normalizedKey, {
+			value,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		});
+		else container[normalizedKey] = value;
+		return "";
+	},
+	has: (container, key) => {
+		const normalizedKey = normalizeKey(key);
+		return normalizedKey !== null && Object.prototype.hasOwnProperty.call(container, normalizedKey);
+	},
+	keys: (container) => Object.keys(container),
+	get: (container, key) => {
+		const normalizedKey = String(key);
+		if (!Object.prototype.hasOwnProperty.call(container, normalizedKey)) return null;
+		return container[normalizedKey];
+	}
+});
+//#endregion
+//#region src/common/snippet.ts
+var DEFAULT_SNIPPET_OPTIONS = {
+	maxLength: 79,
+	indent: 1,
+	linesBefore: 3,
+	linesAfter: 2
+};
+function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
+	let head = "";
+	let tail = "";
+	const maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+	if (position - lineStart > maxHalfLength) {
+		head = " ... ";
+		lineStart = position - maxHalfLength + head.length;
+	}
+	if (lineEnd - position > maxHalfLength) {
+		tail = " ...";
+		lineEnd = position + maxHalfLength - tail.length;
+	}
+	return {
+		str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, "→") + tail,
+		pos: position - lineStart + head.length
+	};
+}
+function padStart(string, max) {
+	return " ".repeat(Math.max(max - string.length, 0)) + string;
+}
+function makeSnippet(mark, options) {
+	if (!mark.buffer) return null;
+	const opts = {
+		...DEFAULT_SNIPPET_OPTIONS,
+		...options
+	};
+	const re = /\r?\n|\r|\0/g;
+	const lineStarts = [0];
+	const lineEnds = [];
+	let match;
+	let foundLineNo = -1;
+	while (match = re.exec(mark.buffer)) {
+		lineEnds.push(match.index);
+		lineStarts.push(match.index + match[0].length);
+		if (mark.position <= match.index && foundLineNo < 0) foundLineNo = lineStarts.length - 2;
+	}
+	if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
+	let result = "";
+	const lineNoLength = Math.min(mark.line + opts.linesAfter, lineEnds.length).toString().length;
+	const maxLineLength = opts.maxLength - (opts.indent + lineNoLength + 3);
+	for (let i = 1; i <= opts.linesBefore; i++) {
+		if (foundLineNo - i < 0) break;
+		const line = getLine(mark.buffer, lineStarts[foundLineNo - i], lineEnds[foundLineNo - i], mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]), maxLineLength);
+		result = `${" ".repeat(opts.indent)}${padStart((mark.line - i + 1).toString(), lineNoLength)} | ${line.str}\n${result}`;
+	}
+	const line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+	result += `${" ".repeat(opts.indent)}${padStart((mark.line + 1).toString(), lineNoLength)} | ${line.str}\n`;
+	result += `${"-".repeat(opts.indent + lineNoLength + 3 + line.pos)}^\n`;
+	for (let i = 1; i <= opts.linesAfter; i++) {
+		if (foundLineNo + i >= lineEnds.length) break;
+		const line = getLine(mark.buffer, lineStarts[foundLineNo + i], lineEnds[foundLineNo + i], mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]), maxLineLength);
+		result += `${" ".repeat(opts.indent)}${padStart((mark.line + i + 1).toString(), lineNoLength)} | ${line.str}\n`;
+	}
+	return result.replace(/\n$/, "");
+}
+//#endregion
+//#region src/common/exception.ts
+function formatError(exception, compact) {
+	let where = "";
+	if (!exception.mark) return exception.reason;
+	if (exception.mark.name) where += `in "${exception.mark.name}" `;
+	where += `(${exception.mark.line + 1}:${exception.mark.column + 1})`;
+	if (!compact && exception.mark.snippet) where += `\n\n${exception.mark.snippet}`;
+	return `${exception.reason} ${where}`;
+}
+var YAMLException = class extends Error {
+	reason;
+	mark;
+	constructor(reason, mark) {
+		super();
+		this.name = "YAMLException";
+		this.reason = reason;
+		this.mark = mark;
+		this.message = formatError(this, false);
+		if (Error.captureStackTrace) Error.captureStackTrace(this, this.constructor);
+	}
+	toString(compact) {
+		return `${this.name}: ${formatError(this, compact)}`;
+	}
+};
+function throwErrorAt(source, position, message, filename = "") {
+	let line = 0;
+	let lineStart = 0;
+	for (let index = 0; index < position; index++) {
+		const ch = source.charCodeAt(index);
+		if (ch === 10) {
+			line++;
+			lineStart = index + 1;
+		} else if (ch === 13) {
+			line++;
+			if (source.charCodeAt(index + 1) === 10) index++;
+			lineStart = index + 1;
+		}
+	}
+	const mark = {
+		name: filename,
+		buffer: source,
+		position,
+		line,
+		column: position - lineStart
+	};
+	mark.snippet = makeSnippet(mark);
+	throw new YAMLException(message, mark);
+}
+//#endregion
+//#region src/parser/events.ts
+var EVENT_DOCUMENT = 1;
+var EVENT_SEQUENCE = 2;
+var EVENT_MAPPING = 3;
+var EVENT_SCALAR = 4;
+var EVENT_ALIAS = 5;
+var EVENT_POP = 6;
+var SCALAR_STYLE_PLAIN = 1;
+var SCALAR_STYLE_SINGLE_QUOTED = 2;
+var SCALAR_STYLE_DOUBLE_QUOTED = 3;
+var SCALAR_STYLE_LITERAL_BLOCK = 4;
+var SCALAR_STYLE_FOLDED_BLOCK = 5;
+var COLLECTION_STYLE_BLOCK = 1;
+var COLLECTION_STYLE_FLOW = 2;
+var CHOMPING_CLIP = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP = 3;
+//#endregion
+//#region src/parser/parser_scalar.ts
+var NO_RANGE$3 = -1;
+function simpleEscapeSequence(c) {
+	switch (c) {
+		case 48: return "\0";
+		case 97: return "\x07";
+		case 98: return "\b";
+		case 116: return "	";
+		case 9: return "	";
+		case 110: return "\n";
+		case 118: return "\v";
+		case 102: return "\f";
+		case 114: return "\r";
+		case 101: return "\x1B";
+		case 32: return " ";
+		case 34: return "\"";
+		case 47: return "/";
+		case 92: return "\\";
+		case 78: return "";
+		case 95: return "\xA0";
+		case 76: return "\u2028";
+		case 80: return "\u2029";
+		default: return "";
+	}
+}
+var simpleEscapeCheck = new Array(256);
+var simpleEscapeMap = new Array(256);
+for (let i = 0; i < 256; i++) {
+	simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+	simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+function charFromCodepoint(c) {
+	if (c <= 65535) return String.fromCharCode(c);
+	return String.fromCharCode((c - 65536 >> 10) + 55296, (c - 65536 & 1023) + 56320);
+}
+function fromHexCode$1(c) {
+	if (c >= 48 && c <= 57) return c - 48;
+	return (c | 32) - 97 + 10;
+}
+function escapedHexLen$1(c) {
+	if (c === 120) return 2;
+	if (c === 117) return 4;
+	return 8;
+}
+function skipFoldedBreaks(input, position, end) {
+	let breaks = 0;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 10) {
+			breaks++;
+			position++;
+		} else if (ch === 13) {
+			breaks++;
+			position++;
+			if (input.charCodeAt(position) === 10) position++;
+		} else if (ch === 32 || ch === 9) position++;
+		else break;
+	}
+	return {
+		position,
+		breaks
+	};
+}
+function foldedBreaks(count) {
+	if (count === 1) return " ";
+	return "\n".repeat(count - 1);
+}
+function getPlainValue(input, start, end) {
+	let result = "";
+	let position = start;
+	let captureStart = start;
+	let captureEnd = start;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 10 || ch === 13) {
+			result += input.slice(captureStart, captureEnd);
+			const fold = skipFoldedBreaks(input, position, end);
+			result += foldedBreaks(fold.breaks);
+			position = captureStart = captureEnd = fold.position;
+		} else {
+			position++;
+			if (ch !== 32 && ch !== 9) captureEnd = position;
+		}
+	}
+	return result + input.slice(captureStart, captureEnd);
+}
+function getSingleQuotedValue(input, start, end) {
+	let result = "";
+	let position = start;
+	let captureStart = start;
+	let captureEnd = start;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 39) {
+			result += input.slice(captureStart, position) + "'";
+			position += 2;
+			captureStart = captureEnd = position;
+		} else if (ch === 10 || ch === 13) {
+			result += input.slice(captureStart, captureEnd);
+			const fold = skipFoldedBreaks(input, position, end);
+			result += foldedBreaks(fold.breaks);
+			position = captureStart = captureEnd = fold.position;
+		} else {
+			position++;
+			if (ch !== 32 && ch !== 9) captureEnd = position;
+		}
+	}
+	return result + input.slice(captureStart, end);
+}
+function getDoubleQuotedValue(input, start, end) {
+	let result = "";
+	let position = start;
+	let captureStart = start;
+	let captureEnd = start;
+	while (position < end) {
+		const ch = input.charCodeAt(position);
+		if (ch === 92) {
+			result += input.slice(captureStart, position);
+			position++;
+			const escaped = input.charCodeAt(position);
+			if (escaped === 10 || escaped === 13) position = skipFoldedBreaks(input, position, end).position;
+			else if (escaped < 256 && simpleEscapeCheck[escaped]) {
+				result += simpleEscapeMap[escaped];
+				position++;
+			} else {
+				let hexLength = escapedHexLen$1(escaped);
+				let hexResult = 0;
+				for (; hexLength > 0; hexLength--) {
+					position++;
+					const digit = fromHexCode$1(input.charCodeAt(position));
+					hexResult = (hexResult << 4) + digit;
+				}
+				result += charFromCodepoint(hexResult);
+				position++;
+			}
+			captureStart = captureEnd = position;
+		} else if (ch === 10 || ch === 13) {
+			result += input.slice(captureStart, captureEnd);
+			const fold = skipFoldedBreaks(input, position, end);
+			result += foldedBreaks(fold.breaks);
+			position = captureStart = captureEnd = fold.position;
+		} else {
+			position++;
+			if (ch !== 32 && ch !== 9) captureEnd = position;
+		}
+	}
+	return result + input.slice(captureStart, end);
+}
+function getBlockValue(input, start, end, indent, chomping, folded) {
+	const textIndent = indent < 0 ? 0 : indent;
+	const region = input.slice(start, end).replace(/\r\n?/g, "\n");
+	const lines = region === "" ? [] : (region.endsWith("\n") ? region.slice(0, -1) : region).split("\n");
+	let result = "";
+	let didReadContent = false;
+	let emptyLines = 0;
+	let atMoreIndented = false;
+	for (const line of lines) {
+		let column = 0;
+		while (column < textIndent && line.charCodeAt(column) === 32) column++;
+		if (indent < 0 || column >= line.length) {
+			emptyLines++;
+			continue;
+		}
+		const content = line.slice(textIndent);
+		const first = content.charCodeAt(0);
+		if (folded) if (first === 32 || first === 9) {
+			atMoreIndented = true;
+			result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
+		} else if (atMoreIndented) {
+			atMoreIndented = false;
+			result += "\n".repeat(emptyLines + 1);
+		} else if (emptyLines === 0) {
+			if (didReadContent) result += " ";
+		} else result += "\n".repeat(emptyLines);
+		else result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
+		result += content;
+		didReadContent = true;
+		emptyLines = 0;
+	}
+	if (chomping === 3) result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
+	else if (chomping !== 2) {
+		if (didReadContent) result += "\n";
+	}
+	return result;
+}
+function getScalarValue(input, scalar) {
+	if (scalar.valueStart === NO_RANGE$3) return "";
+	const { valueStart, valueEnd } = scalar;
+	if (scalar.fast) return input.slice(valueStart, valueEnd);
+	switch (scalar.style) {
+		case 2: return getSingleQuotedValue(input, valueStart, valueEnd);
+		case 3: return getDoubleQuotedValue(input, valueStart, valueEnd);
+		case 4: return getBlockValue(input, valueStart, valueEnd, scalar.indent, scalar.chomping, false);
+		case 5: return getBlockValue(input, valueStart, valueEnd, scalar.indent, scalar.chomping, true);
+		default: return getPlainValue(input, valueStart, valueEnd);
+	}
+}
+//#endregion
+//#region src/common/tagname.ts
+var DEFAULT_TAG_HANDLERS = Object.assign(Object.create(null), {
+	"!": "!",
+	"!!": "tag:yaml.org,2002:"
+});
+function tagPercentEncode(source) {
+	return encodeURI(source).replace(/!/g, "%21");
+}
+function tagNameFull(rawTag, tagHandlers) {
+	if (rawTag.startsWith("!<") && rawTag.endsWith(">")) return decodeURIComponent(rawTag.slice(2, -1));
+	const handleEnd = rawTag.indexOf("!", 1);
+	const handle = handleEnd === -1 ? "!" : rawTag.slice(0, handleEnd + 1);
+	const prefix = tagHandlers?.[handle] ?? DEFAULT_TAG_HANDLERS[handle] ?? handle;
+	return decodeURIComponent(prefix) + decodeURIComponent(rawTag.slice(handle.length));
+}
+function tagNameShort(fullTag) {
+	let tag = fullTag;
+	if (tag.charCodeAt(0) === 33) {
+		tag = tag.slice(1);
+		return `!${tagPercentEncode(tag)}`;
+	}
+	if (tag.slice(0, 18) === "tag:yaml.org,2002:") return `!!${tagPercentEncode(tag.slice(18))}`;
+	return `!<${tagPercentEncode(tag)}>`;
+}
+//#endregion
+//#region src/parser/constructor.ts
+var NO_RANGE$2 = -1;
+var DEFAULT_CONSTRUCTOR_OPTIONS = {
+	filename: "",
+	schema: CORE_SCHEMA,
+	json: false,
+	maxTotalMergeKeys: 1e4,
+	maxAliases: -1
+};
+function eventPosition$1(event) {
+	if ("tagStart" in event && event.tagStart !== NO_RANGE$2) return event.tagStart;
+	if ("anchorStart" in event && event.anchorStart !== NO_RANGE$2) return event.anchorStart;
+	if ("valueStart" in event && event.valueStart !== NO_RANGE$2) return event.valueStart;
+	if ("start" in event) return event.start;
+	return 0;
+}
+function throwError$1(state, message) {
+	throwErrorAt(state.source, state.position, message, state.filename);
+}
+function finalizeCollection(state, position, tag, carrier) {
+	try {
+		return tag.finalize(carrier);
+	} catch (error) {
+		if (error instanceof YAMLException) throw error;
+		throwErrorAt(state.source, position, error instanceof Error ? error.message : String(error), state.filename);
+	}
+}
+function lookupTag(exact, prefix, tagName) {
+	const exactTag = exact[tagName];
+	if (exactTag) return exactTag;
+	for (const tag of prefix) if (tagName.startsWith(tag.tagName)) return tag;
+}
+function findExplicitTag(state, exact, prefix, tagName, nodeKind) {
+	const tag = lookupTag(exact, prefix, tagName);
+	if (tag) return tag;
+	throwError$1(state, `unknown ${nodeKind} tag !<${tagName}>`);
+}
+function constructScalar(state, event) {
+	const source = getScalarValue(state.source, event);
+	const rawTag = event.tagStart === NO_RANGE$2 ? "" : state.source.slice(event.tagStart, event.tagEnd);
+	const strTag = state.schema.defaultScalarTag;
+	if (rawTag !== "") {
+		if (rawTag === "!") return {
+			value: source,
+			tag: strTag
+		};
+		const tagName = tagNameFull(rawTag, state.tagHandlers);
+		const scalarTag = lookupTag(state.schema.exact.scalar, state.schema.prefix.scalar, tagName);
+		if (scalarTag) {
+			const result = scalarTag.resolve(source, true, tagName);
+			if (result === NOT_RESOLVED) throwError$1(state, `cannot resolve a node with !<${tagName}> explicit tag`);
+			return {
+				value: result,
+				tag: scalarTag
+			};
+		}
+		const collectionTagDef = lookupTag(state.schema.exact.mapping, state.schema.prefix.mapping, tagName) ?? lookupTag(state.schema.exact.sequence, state.schema.prefix.sequence, tagName);
+		if (collectionTagDef) {
+			if (source !== "") throwError$1(state, `cannot resolve a node with !<${tagName}> explicit tag`);
+			const carrier = collectionTagDef.create(tagName);
+			return {
+				value: collectionTagDef.carrierIsResult ? carrier : finalizeCollection(state, state.position, collectionTagDef, carrier),
+				tag: collectionTagDef
+			};
+		}
+		throwError$1(state, `unknown scalar tag !<${tagName}>`);
+	}
+	if (event.style === 1) {
+		const candidates = state.schema.implicitScalarByFirstChar.get(source.charAt(0)) ?? state.schema.implicitScalarAnyFirstChar;
+		for (const tag of candidates) {
+			const result = tag.resolve(source, false, tag.tagName);
+			if (result !== NOT_RESOLVED) return {
+				value: result,
+				tag
+			};
+		}
+	}
+	return {
+		value: strTag.resolve(source, false, strTag.tagName),
+		tag: strTag
+	};
+}
+function collectionTag(state, event, exact, prefix, defaultTagName, nodeKind) {
+	const rawTag = event.tagStart === NO_RANGE$2 ? "" : state.source.slice(event.tagStart, event.tagEnd);
+	const tagName = rawTag === "" || rawTag === "!" ? defaultTagName : tagNameFull(rawTag, state.tagHandlers);
+	return {
+		tagName,
+		tag: findExplicitTag(state, exact, prefix, tagName, nodeKind)
+	};
+}
+function isMappingTag(tag) {
+	return tag.nodeKind === "mapping";
+}
+function mergeKeys(state, frame, source, sourceTag) {
+	for (const sourceKey of sourceTag.keys(source)) {
+		if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) throwError$1(state, `merge keys exceeded maxTotalMergeKeys (${state.maxTotalMergeKeys})`);
+		if (frame.tag.has(frame.value, sourceKey)) continue;
+		const err = frame.tag.addPair(frame.value, sourceKey, sourceTag.get(source, sourceKey));
+		if (err) throwError$1(state, err);
+		(frame.overridable ??= /* @__PURE__ */ new Set()).add(sourceKey);
+	}
+}
+function mergeSource(state, frame, source, sourceTag) {
+	state.position = frame.keyPosition;
+	if (isMappingTag(sourceTag)) mergeKeys(state, frame, source, sourceTag);
+	else if (sourceTag.nodeKind === "sequence" && Array.isArray(source)) for (const element of source) mergeKeys(state, frame, element, frame.tag);
+	else throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+}
+function addMappingValue(state, frame, key, value, tag) {
+	state.position = frame.keyPosition;
+	if (key === MERGE_KEY) {
+		mergeSource(state, frame, value, tag);
+		return;
+	}
+	if (!state.json && frame.tag.has(frame.value, key) && !frame.overridable?.has(key)) throwError$1(state, "duplicated mapping key");
+	const err = frame.tag.addPair(frame.value, key, value);
+	if (err) throwError$1(state, err);
+	frame.overridable?.delete(key);
+}
+function addValue(state, value, tag) {
+	const frame = state.frames[state.frames.length - 1];
+	if (frame.kind === "document") {
+		frame.value = value;
+		frame.hasValue = true;
+	} else if (frame.kind === "sequence") {
+		if (frame.merge) {
+			if (!isMappingTag(tag)) throwError$1(state, "cannot merge mappings; the provided source object is unacceptable");
+		}
+		const err = frame.tag.addItem(frame.value, value, frame.index++);
+		if (err) throwError$1(state, err);
+	} else if (frame.hasKey) {
+		const key = frame.key;
+		frame.key = void 0;
+		frame.hasKey = false;
+		addMappingValue(state, frame, key, value, tag);
+	} else {
+		frame.key = value;
+		frame.keyPosition = state.position;
+		frame.hasKey = true;
+	}
+}
+function storeAnchor(state, event, value, tag, isValueFinal) {
+	if (event.anchorStart !== NO_RANGE$2) {
+		const anchor = {
+			value,
+			tag,
+			isValueFinal
+		};
+		state.anchors.set(state.source.slice(event.anchorStart, event.anchorEnd), anchor);
+		return anchor;
+	}
+	return null;
+}
+function constructFromEvents(events, options) {
+	const state = {
+		...DEFAULT_CONSTRUCTOR_OPTIONS,
+		...options,
+		events,
+		documents: [],
+		eventIndex: 0,
+		position: 0,
+		frames: [],
+		anchors: /* @__PURE__ */ new Map(),
+		tagHandlers: Object.create(null),
+		totalMergeKeys: 0,
+		aliasCount: 0
+	};
+	while (state.eventIndex < state.events.length) {
+		const event = state.events[state.eventIndex++];
+		state.position = eventPosition$1(event);
+		switch (event.type) {
+			case 1:
+				state.anchors = /* @__PURE__ */ new Map();
+				state.aliasCount = 0;
+				state.tagHandlers = Object.create(null);
+				for (const directive of event.directives) if (directive.kind === "tag") state.tagHandlers[directive.handle] = directive.prefix;
+				state.frames.push({
+					kind: "document",
+					position: state.position,
+					value: void 0,
+					hasValue: false
+				});
+				break;
+			case 4: {
+				const { value, tag } = constructScalar(state, event);
+				storeAnchor(state, event, value, tag, true);
+				addValue(state, value, tag);
+				break;
+			}
+			case 2: {
+				const definition = collectionTag(state, event, state.schema.exact.sequence, state.schema.prefix.sequence, "tag:yaml.org,2002:seq", "sequence");
+				const value = definition.tag.create(definition.tagName);
+				const anchor = storeAnchor(state, event, value, definition.tag, definition.tag.carrierIsResult);
+				const parent = state.frames[state.frames.length - 1];
+				const merge = parent !== void 0 && parent.kind === "mapping" && parent.hasKey && parent.key === MERGE_KEY;
+				state.frames.push({
+					kind: "sequence",
+					position: state.position,
+					value,
+					tag: definition.tag,
+					anchor,
+					index: 0,
+					merge
+				});
+				break;
+			}
+			case 3: {
+				const definition = collectionTag(state, event, state.schema.exact.mapping, state.schema.prefix.mapping, "tag:yaml.org,2002:map", "mapping");
+				const value = definition.tag.create(definition.tagName);
+				const anchor = storeAnchor(state, event, value, definition.tag, definition.tag.carrierIsResult);
+				state.frames.push({
+					kind: "mapping",
+					position: state.position,
+					value,
+					tag: definition.tag,
+					anchor,
+					key: void 0,
+					keyPosition: state.position,
+					hasKey: false,
+					overridable: null
+				});
+				break;
+			}
+			case 5: {
+				if (state.maxAliases !== -1 && ++state.aliasCount > state.maxAliases) throwError$1(state, `aliases exceeded maxAliases (${state.maxAliases})`);
+				const name = state.source.slice(event.anchorStart, event.anchorEnd);
+				const anchor = state.anchors.get(name);
+				if (!anchor) throwError$1(state, `unidentified alias "${name}"`);
+				if (!anchor.isValueFinal) throwError$1(state, `recursive alias "${name}" is not supported for tag ${anchor.tag.tagName} because it uses finalize()`);
+				addValue(state, anchor.value, anchor.tag);
+				break;
+			}
+			case 6: {
+				const frame = state.frames.pop();
+				if (frame.kind === "mapping" && frame.hasKey) {
+					state.position = frame.keyPosition;
+					throwError$1(state, "incomplete mapping pair in event stream");
+				}
+				if (frame.kind === "document") state.documents.push(frame.value);
+				else {
+					const value = frame.tag.carrierIsResult ? frame.value : finalizeCollection(state, frame.position, frame.tag, frame.value);
+					if (frame.anchor) {
+						frame.anchor.value = value;
+						frame.anchor.isValueFinal = true;
+					}
+					addValue(state, value, frame.tag);
+				}
+				break;
+			}
+		}
+	}
+	return state.documents;
+}
+//#endregion
+//#region src/parser/parser.ts
+var NO_RANGE$1 = -1;
+var HAS_OWN = Object.prototype.hasOwnProperty;
+var CONTEXT_FLOW_IN = 1;
+var CONTEXT_FLOW_OUT = 2;
+var CONTEXT_BLOCK_IN = 3;
+var CONTEXT_BLOCK_OUT = 4;
+var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+var PATTERN_FLOW_INDICATORS = /[,\[\]{}]/;
+var PATTERN_TAG_HANDLE = /^(?:!|!!|![0-9A-Za-z-]+!)$/;
+var NS_URI_CHAR = String.raw`(?:%[0-9A-Fa-f]{2}|[0-9A-Za-z\-#;/?:@&=+$,_.!~*'()\[\]])`;
+var NS_TAG_CHAR = String.raw`(?:%[0-9A-Fa-f]{2}|[0-9A-Za-z\-#;/?:@&=+$.~*'()_])`;
+var PATTERN_TAG_URI = new RegExp(`^(?:${NS_URI_CHAR})*$`);
+var PATTERN_TAG_SUFFIX = new RegExp(`^(?:${NS_TAG_CHAR})+$`);
+var PATTERN_TAG_PREFIX = new RegExp(`^(?:!(?:${NS_URI_CHAR})*|${NS_TAG_CHAR}(?:${NS_URI_CHAR})*)$`);
+var DEFAULT_PARSER_OPTIONS = {
+	filename: "",
+	maxDepth: 100
+};
+function addDocumentEvent(state, explicitStart, explicitEnd) {
+	state.events.push({
+		type: 1,
+		explicitStart,
+		explicitEnd,
+		directives: state.directives
+	});
+}
+function addSequenceEvent(state, start, anchorStart, anchorEnd, tagStart, tagEnd, style) {
+	state.events.push({
+		type: 2,
+		start,
+		anchorStart,
+		anchorEnd,
+		tagStart,
+		tagEnd,
+		style
+	});
+}
+function addMappingEvent(state, start, anchorStart, anchorEnd, tagStart, tagEnd, style) {
+	state.events.push({
+		type: 3,
+		start,
+		anchorStart,
+		anchorEnd,
+		tagStart,
+		tagEnd,
+		style
+	});
+}
+function insertFlowPairMappingEvent(state, snapshot) {
+	state.events.splice(snapshot.eventsLength, 0, {
+		type: 3,
+		start: snapshot.position,
+		anchorStart: NO_RANGE$1,
+		anchorEnd: NO_RANGE$1,
+		tagStart: NO_RANGE$1,
+		tagEnd: NO_RANGE$1,
+		style: 2
+	});
+}
+function addScalarEvent(state, valueStart, valueEnd, anchorStart, anchorEnd, tagStart, tagEnd, style, chomping = 1, indent = -1, fast = false) {
+	state.events.push({
+		type: 4,
+		valueStart,
+		valueEnd,
+		anchorStart,
+		anchorEnd,
+		tagStart,
+		tagEnd,
+		style,
+		chomping,
+		indent,
+		fast
+	});
+}
+function addAliasEvent(state, anchorStart, anchorEnd) {
+	state.events.push({
+		type: 5,
+		anchorStart,
+		anchorEnd
+	});
+}
+function addPopEvent(state) {
+	state.events.push({ type: 6 });
+}
+function addEmptyScalarEvent(state) {
+	addScalarEvent(state, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, NO_RANGE$1, 1);
+}
+function emptyProperties() {
+	return {
+		anchorStart: NO_RANGE$1,
+		anchorEnd: NO_RANGE$1,
+		tagStart: NO_RANGE$1,
+		tagEnd: NO_RANGE$1
+	};
+}
+function snapshotState(state) {
+	return {
+		position: state.position,
+		line: state.line,
+		lineStart: state.lineStart,
+		lineIndent: state.lineIndent,
+		firstTabInLine: state.firstTabInLine,
+		eventsLength: state.events.length
+	};
+}
+function restoreState(state, snapshot) {
+	state.position = snapshot.position;
+	state.line = snapshot.line;
+	state.lineStart = snapshot.lineStart;
+	state.lineIndent = snapshot.lineIndent;
+	state.firstTabInLine = snapshot.firstTabInLine;
+	state.events.length = snapshot.eventsLength;
+}
+function throwError(state, message) {
+	throwErrorAt(state.input.slice(0, state.length), state.position, message, state.filename);
+}
+function isEol(c) {
+	return c === 10 || c === 13;
+}
+function isWhiteSpace(c) {
+	return c === 9 || c === 32;
+}
+function isWsOrEol(c) {
+	return isWhiteSpace(c) || isEol(c);
+}
+function isWsOrEolOrEnd(c) {
+	return c === 0 || isWsOrEol(c);
+}
+function isFlowIndicator(c) {
+	return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
+}
+function fromDecimalCode(c) {
+	return c >= 48 && c <= 57 ? c - 48 : -1;
+}
+function fromHexCode(c) {
+	if (c >= 48 && c <= 57) return c - 48;
+	const lc = c | 32;
+	if (lc >= 97 && lc <= 102) return lc - 97 + 10;
+	return -1;
+}
+function escapedHexLen(c) {
+	if (c === 120) return 2;
+	if (c === 117) return 4;
+	if (c === 85) return 8;
+	return 0;
+}
+function isSimpleEscape(c) {
+	return c === 48 || c === 97 || c === 98 || c === 116 || c === 9 || c === 110 || c === 118 || c === 102 || c === 114 || c === 101 || c === 32 || c === 34 || c === 47 || c === 92 || c === 78 || c === 95 || c === 76 || c === 80;
+}
+function consumeLineBreak(state) {
+	if (state.input.charCodeAt(state.position) === 10) state.position++;
+	else {
+		state.position++;
+		if (state.input.charCodeAt(state.position) === 10) state.position++;
+	}
+	state.line++;
+	state.lineStart = state.position;
+	state.lineIndent = 0;
+	state.firstTabInLine = -1;
+}
+function skipSeparationSpace(state, allowComments) {
+	let lineBreaks = 0;
+	let ch = state.input.charCodeAt(state.position);
+	let hasSeparation = state.position === state.lineStart || isWsOrEol(state.input.charCodeAt(state.position - 1));
+	while (ch !== 0) {
+		while (isWhiteSpace(ch)) {
+			hasSeparation = true;
+			if (ch === 9 && state.firstTabInLine === -1) state.firstTabInLine = state.position;
+			ch = state.input.charCodeAt(++state.position);
+		}
+		if (allowComments && hasSeparation && ch === 35) do
+			ch = state.input.charCodeAt(++state.position);
+		while (!isEol(ch) && ch !== 0);
+		if (!isEol(ch)) break;
+		consumeLineBreak(state);
+		lineBreaks++;
+		hasSeparation = true;
+		ch = state.input.charCodeAt(state.position);
+		while (ch === 32) {
+			state.lineIndent++;
+			ch = state.input.charCodeAt(++state.position);
+		}
+	}
+	return lineBreaks;
+}
+function testDocumentSeparator(state, position = state.position) {
+	const ch = state.input.charCodeAt(position);
+	if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(position + 1) && ch === state.input.charCodeAt(position + 2)) {
+		const following = state.input.charCodeAt(position + 3);
+		return following === 0 || isWsOrEol(following);
+	}
+	return false;
+}
+function skipUntilLineEnd(state) {
+	let ch = state.input.charCodeAt(state.position);
+	while (ch !== 0 && !isEol(ch)) ch = state.input.charCodeAt(++state.position);
+}
+function checkPrintable(state, start, end) {
+	if (PATTERN_NON_PRINTABLE.test(state.input.slice(start, end))) throwError(state, "the stream contains non-printable characters");
+}
+function readTagProperty(state, props, inFlow) {
+	if (state.input.charCodeAt(state.position) !== 33) return false;
+	if (props.tagStart !== NO_RANGE$1) throwError(state, "duplication of a tag property");
+	const start = state.position;
+	let isVerbatim = false;
+	let isNamed = false;
+	let tagHandle = "!";
+	let ch = state.input.charCodeAt(++state.position);
+	if (ch === 60) {
+		isVerbatim = true;
+		ch = state.input.charCodeAt(++state.position);
+	} else if (ch === 33) {
+		isNamed = true;
+		tagHandle = "!!";
+		ch = state.input.charCodeAt(++state.position);
+	}
+	let suffixStart = state.position;
+	let tagName;
+	if (isVerbatim) {
+		while (ch !== 0 && ch !== 62) ch = state.input.charCodeAt(++state.position);
+		if (ch !== 62) throwError(state, "unexpected end of the stream within a verbatim tag");
+		tagName = state.input.slice(suffixStart, state.position);
+		state.position++;
+	} else {
+		while (ch !== 0 && !isWsOrEol(ch) && !(inFlow && isFlowIndicator(ch))) {
+			if (ch === 33) if (!isNamed) {
+				tagHandle = state.input.slice(suffixStart - 1, state.position + 1);
+				if (!PATTERN_TAG_HANDLE.test(tagHandle)) throwError(state, "named tag handle cannot contain such characters");
+				isNamed = true;
+				suffixStart = state.position + 1;
+			} else throwError(state, "tag suffix cannot contain exclamation marks");
+			ch = state.input.charCodeAt(++state.position);
+		}
+		tagName = state.input.slice(suffixStart, state.position);
+		if (PATTERN_FLOW_INDICATORS.test(tagName)) throwError(state, "tag suffix cannot contain flow indicator characters");
+	}
+	if (tagName && !(isVerbatim ? PATTERN_TAG_URI.test(tagName) : PATTERN_TAG_SUFFIX.test(tagName))) throwError(state, `tag name cannot contain such characters: ${tagName}`);
+	if (!isVerbatim && tagHandle !== "!" && tagHandle !== "!!" && !HAS_OWN.call(state.tagHandlers, tagHandle)) throwError(state, `undeclared tag handle "${tagHandle}"`);
+	props.tagStart = start;
+	props.tagEnd = state.position;
+	return true;
+}
+function readAnchorProperty(state, props) {
+	if (state.input.charCodeAt(state.position) !== 38) return false;
+	if (props.anchorStart !== NO_RANGE$1) throwError(state, "duplication of an anchor property");
+	state.position++;
+	const start = state.position;
+	while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position)) && !isFlowIndicator(state.input.charCodeAt(state.position))) state.position++;
+	if (state.position === start) throwError(state, "name of an anchor node must contain at least one character");
+	props.anchorStart = start;
+	props.anchorEnd = state.position;
+	return true;
+}
+function readAlias(state, props) {
+	if (state.input.charCodeAt(state.position) !== 42) return false;
+	if (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1) throwError(state, "alias node should not have any properties");
+	state.position++;
+	const start = state.position;
+	while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position)) && !isFlowIndicator(state.input.charCodeAt(state.position))) state.position++;
+	if (state.position === start) throwError(state, "name of an alias node must contain at least one character");
+	addAliasEvent(state, start, state.position);
+	return true;
+}
+function readFlowScalarBreak(state, nodeIndent) {
+	skipSeparationSpace(state, false);
+	if (state.lineIndent < nodeIndent) throwError(state, "deficient indentation");
+}
+function readSingleQuotedScalar(state, nodeIndent, props) {
+	if (state.input.charCodeAt(state.position) !== 39) return false;
+	state.position++;
+	const start = state.position;
+	let simple = true;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const ch = state.input.charCodeAt(state.position);
+		if (ch === 39) {
+			if (state.input.charCodeAt(state.position + 1) === 39) {
+				simple = false;
+				state.position += 2;
+				continue;
+			}
+			const end = state.position;
+			state.position++;
+			addScalarEvent(state, start, end, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 2, 1, -1, simple);
+			return true;
+		}
+		if (isEol(ch)) {
+			simple = false;
+			readFlowScalarBreak(state, nodeIndent);
+		} else if (state.position === state.lineStart && testDocumentSeparator(state)) throwError(state, "unexpected end of the document within a single quoted scalar");
+		else if (ch !== 9 && ch < 32) throwError(state, "expected valid JSON character");
+		else state.position++;
+	}
+	throwError(state, "unexpected end of the stream within a single quoted scalar");
+}
+function readDoubleQuotedScalar(state, nodeIndent, props) {
+	if (state.input.charCodeAt(state.position) !== 34) return false;
+	state.position++;
+	const start = state.position;
+	let simple = true;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const ch = state.input.charCodeAt(state.position);
+		if (ch === 34) {
+			const end = state.position;
+			state.position++;
+			addScalarEvent(state, start, end, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 3, 1, -1, simple);
+			return true;
+		}
+		if (ch === 92) {
+			simple = false;
+			const escaped = state.input.charCodeAt(++state.position);
+			if (isEol(escaped)) readFlowScalarBreak(state, nodeIndent);
+			else if (isSimpleEscape(escaped)) state.position++;
+			else {
+				let hexLength = escapedHexLen(escaped);
+				if (hexLength === 0) throwError(state, "unknown escape sequence");
+				while (hexLength-- > 0) {
+					state.position++;
+					if (fromHexCode(state.input.charCodeAt(state.position)) < 0) throwError(state, "expected hexadecimal character");
+				}
+				state.position++;
+			}
+		} else if (isEol(ch)) {
+			simple = false;
+			readFlowScalarBreak(state, nodeIndent);
+		} else if (state.position === state.lineStart && testDocumentSeparator(state)) throwError(state, "unexpected end of the document within a double quoted scalar");
+		else if (ch !== 9 && ch < 32) throwError(state, "expected valid JSON character");
+		else state.position++;
+	}
+	throwError(state, "unexpected end of the stream within a double quoted scalar");
+}
+function readBlockScalar(state, parentIndent, props) {
+	const ch = state.input.charCodeAt(state.position);
+	let chomping = 1;
+	let indent = -1;
+	let detectedIndent = false;
+	if (ch !== 124 && ch !== 62) return false;
+	const style = ch === 124 ? 4 : 5;
+	state.position++;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const current = state.input.charCodeAt(state.position);
+		const digit = fromDecimalCode(current);
+		if (current === 43 || current === 45) {
+			if (chomping !== 1) throwError(state, "repeat of a chomping mode identifier");
+			chomping = current === 43 ? 3 : 2;
+			state.position++;
+		} else if (digit >= 0) {
+			if (digit === 0) throwError(state, "bad explicit indentation width of a block scalar; it cannot be less than one");
+			if (detectedIndent) throwError(state, "repeat of an indentation width identifier");
+			indent = parentIndent + digit - 1;
+			detectedIndent = true;
+			state.position++;
+		} else break;
+	}
+	let hadWhitespace = false;
+	while (isWhiteSpace(state.input.charCodeAt(state.position))) {
+		hadWhitespace = true;
+		state.position++;
+	}
+	if (hadWhitespace && state.input.charCodeAt(state.position) === 35) skipUntilLineEnd(state);
+	if (isEol(state.input.charCodeAt(state.position))) consumeLineBreak(state);
+	else if (state.input.charCodeAt(state.position) !== 0) throwError(state, "a line break is expected");
+	let contentIndent = detectedIndent ? indent : -1;
+	let maxLeadingIndent = 0;
+	const valueStart = state.position;
+	let valueEnd = state.position;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		const linePosition = state.position;
+		let column = 0;
+		while (state.input.charCodeAt(linePosition + column) === 32) column++;
+		const first = state.input.charCodeAt(linePosition + column);
+		if (first === 0) {
+			if (contentIndent >= 0) {
+				if (column > contentIndent) valueEnd = linePosition + column;
+			} else if (column > 0) valueEnd = linePosition + column;
+			break;
+		}
+		if (linePosition === state.lineStart && testDocumentSeparator(state, linePosition)) break;
+		if (!detectedIndent && contentIndent === -1 && isEol(first)) maxLeadingIndent = Math.max(maxLeadingIndent, column);
+		if (!detectedIndent && contentIndent === -1 && !isEol(first)) {
+			if (first === 9 && column < parentIndent) {
+				state.position = linePosition + column;
+				throwError(state, "tab characters must not be used in indentation");
+			}
+			if (column < maxLeadingIndent) {
+				state.position = linePosition + column;
+				throwError(state, "bad indentation of a mapping entry");
+			}
+		}
+		if (contentIndent === -1 && first !== 0 && !isEol(first) && column < parentIndent) {
+			state.lineIndent = column;
+			state.position = linePosition + column;
+			break;
+		}
+		if (!detectedIndent && first !== 0 && !isEol(first) && contentIndent === -1) contentIndent = column;
+		const requiredIndent = contentIndent === -1 ? parentIndent + 1 : contentIndent;
+		if (first !== 0 && !isEol(first) && column < requiredIndent) {
+			state.lineIndent = column;
+			state.position = linePosition + column;
+			break;
+		}
+		skipUntilLineEnd(state);
+		valueEnd = state.position;
+		if (isEol(state.input.charCodeAt(state.position))) {
+			consumeLineBreak(state);
+			valueEnd = state.position;
+		}
+	}
+	checkPrintable(state, valueStart, valueEnd);
+	addScalarEvent(state, valueStart, valueEnd, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, style, chomping, contentIndent);
+	return true;
+}
+function canStartPlainScalar(state, nodeContext) {
+	const ch = state.input.charCodeAt(state.position);
+	const inFlow = nodeContext === CONTEXT_FLOW_IN;
+	if (ch === 0 || isWsOrEol(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96 || inFlow && isFlowIndicator(ch)) return false;
+	if (ch === 63 || ch === 45) {
+		const following = state.input.charCodeAt(state.position + 1);
+		if (isWsOrEolOrEnd(following) || inFlow && isFlowIndicator(following)) return false;
+	}
+	return true;
+}
+function readPlainScalar(state, nodeIndent, nodeContext, props) {
+	if (!canStartPlainScalar(state, nodeContext)) return false;
+	const start = state.position;
+	let end = state.position;
+	let ch = state.input.charCodeAt(state.position);
+	const inFlow = nodeContext === CONTEXT_FLOW_IN;
+	let multiline = false;
+	while (ch !== 0) {
+		if (state.position === state.lineStart && testDocumentSeparator(state)) break;
+		if (ch === 58) {
+			const following = state.input.charCodeAt(state.position + 1);
+			if (isWsOrEolOrEnd(following) || inFlow && isFlowIndicator(following)) break;
+		} else if (ch === 35) {
+			if (isWsOrEol(state.input.charCodeAt(state.position - 1))) break;
+		} else if (inFlow && isFlowIndicator(ch)) break;
+		else if (isEol(ch)) {
+			const savedPosition = state.position;
+			const savedLine = state.line;
+			const savedLineStart = state.lineStart;
+			const savedLineIndent = state.lineIndent;
+			skipSeparationSpace(state, false);
+			if (state.lineIndent >= nodeIndent) {
+				multiline = true;
+				ch = state.input.charCodeAt(state.position);
+				continue;
+			}
+			state.position = savedPosition;
+			state.line = savedLine;
+			state.lineStart = savedLineStart;
+			state.lineIndent = savedLineIndent;
+			break;
+		}
+		if (!isWhiteSpace(ch)) end = state.position + 1;
+		ch = state.input.charCodeAt(++state.position);
+	}
+	if (end === start) return false;
+	checkPrintable(state, start, end);
+	addScalarEvent(state, start, end, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1, 1, -1, !multiline);
+	return true;
+}
+function skipFlowSeparationSpace(state, nodeIndent) {
+	const startLine = state.line;
+	skipSeparationSpace(state, true);
+	if (state.line > startLine && state.lineIndent < nodeIndent || state.firstTabInLine !== -1 && state.lineIndent < nodeIndent) throwError(state, "deficient indentation");
+}
+function readFlowCollection(state, nodeIndent, props) {
+	const ch = state.input.charCodeAt(state.position);
+	const isMapping = ch === 123;
+	const start = state.position;
+	let readNext = true;
+	if (ch !== 91 && ch !== 123) return false;
+	const terminator = isMapping ? 125 : 93;
+	if (isMapping) addMappingEvent(state, start, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 2);
+	else addSequenceEvent(state, start, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 2);
+	state.position++;
+	while (state.input.charCodeAt(state.position) !== 0) {
+		skipFlowSeparationSpace(state, nodeIndent);
+		let ch = state.input.charCodeAt(state.position);
+		if (ch === terminator) {
+			state.position++;
+			addPopEvent(state);
+			return true;
+		} else if (!readNext) throwError(state, "missed comma between flow collection entries");
+		else if (ch === 44) throwError(state, "expected the node content, but found ','");
+		let isPair = false;
+		let isExplicitPair = false;
+		if (ch === 63 && isWsOrEol(state.input.charCodeAt(state.position + 1))) {
+			isPair = isExplicitPair = true;
+			state.position += 1;
+			skipFlowSeparationSpace(state, nodeIndent);
+		}
+		const entryLine = state.line;
+		const entryStart = snapshotState(state);
+		const keyWasRead = parseNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+		skipFlowSeparationSpace(state, nodeIndent);
+		ch = state.input.charCodeAt(state.position);
+		if ((isMapping || isExplicitPair || state.line === entryLine) && ch === 58) {
+			isPair = true;
+			state.position++;
+			skipFlowSeparationSpace(state, nodeIndent);
+			if (!isMapping) {
+				insertFlowPairMappingEvent(state, entryStart);
+				if (!keyWasRead) addEmptyScalarEvent(state);
+			} else if (!keyWasRead) addEmptyScalarEvent(state);
+			if (!parseNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true)) addEmptyScalarEvent(state);
+			skipFlowSeparationSpace(state, nodeIndent);
+			if (!isMapping) addPopEvent(state);
+		} else if (isMapping && isPair) {
+			if (!keyWasRead) addEmptyScalarEvent(state);
+			addEmptyScalarEvent(state);
+		} else if (isMapping) addEmptyScalarEvent(state);
+		else if (isPair) {
+			insertFlowPairMappingEvent(state, entryStart);
+			if (!keyWasRead) addEmptyScalarEvent(state);
+			addEmptyScalarEvent(state);
+			addPopEvent(state);
+		}
+		ch = state.input.charCodeAt(state.position);
+		if (ch === 44) {
+			readNext = true;
+			state.position++;
+		} else readNext = false;
+	}
+	throwError(state, "unexpected end of the stream within a flow collection");
+}
+function readBlockSequence(state, nodeIndent, props) {
+	if (state.firstTabInLine !== -1 || state.input.charCodeAt(state.position) !== 45 || !isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) return false;
+	addSequenceEvent(state, state.position, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+	while (state.input.charCodeAt(state.position) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) {
+		if (state.firstTabInLine !== -1) {
+			state.position = state.firstTabInLine;
+			throwError(state, "tab characters must not be used in indentation");
+		}
+		const entryLine = state.line;
+		state.position++;
+		const hadBreak = skipSeparationSpace(state, true) > 0;
+		if (state.firstTabInLine !== -1 && state.input.charCodeAt(state.position) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) throwError(state, "bad indentation of a sequence entry");
+		if (hadBreak && state.lineIndent <= nodeIndent) addEmptyScalarEvent(state);
+		else parseNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+		skipSeparationSpace(state, true);
+		if (state.lineIndent < nodeIndent || state.position >= state.length) break;
+		if (state.lineIndent > nodeIndent) throwError(state, "bad indentation of a sequence entry");
+		if (state.line === entryLine && state.input.charCodeAt(state.position) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 1))) throwError(state, "bad indentation of a sequence entry");
+	}
+	addPopEvent(state);
+	return true;
+}
+function readBlockMapping(state, nodeIndent, flowIndent, props) {
+	let atExplicitKey = false;
+	let detected = false;
+	let mappingOpened = false;
+	let pendingExplicitKey = false;
+	if (state.firstTabInLine !== -1) return false;
+	let ch = state.input.charCodeAt(state.position);
+	while (ch !== 0) {
+		if (!atExplicitKey && state.firstTabInLine !== -1) {
+			state.position = state.firstTabInLine;
+			throwError(state, "tab characters must not be used in indentation");
+		}
+		const following = state.input.charCodeAt(state.position + 1);
+		const entryLine = state.line;
+		if ((ch === 63 || ch === 58) && isWsOrEolOrEnd(following)) {
+			if (!mappingOpened) {
+				addMappingEvent(state, state.position, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+				mappingOpened = true;
+			}
+			if (ch === 63) {
+				if (atExplicitKey) addEmptyScalarEvent(state);
+				detected = true;
+				atExplicitKey = true;
+			} else if (atExplicitKey) atExplicitKey = false;
+			else {
+				addEmptyScalarEvent(state);
+				detected = true;
+				atExplicitKey = false;
+			}
+			state.position += 1;
+			pendingExplicitKey = true;
+		} else {
+			if (atExplicitKey) {
+				addEmptyScalarEvent(state);
+				atExplicitKey = false;
+			}
+			const beforeKey = snapshotState(state);
+			if (!parseNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) break;
+			if (state.line === entryLine) {
+				ch = state.input.charCodeAt(state.position);
+				while (isWhiteSpace(ch)) ch = state.input.charCodeAt(++state.position);
+				if (ch === 58) {
+					ch = state.input.charCodeAt(++state.position);
+					if (!isWsOrEolOrEnd(ch)) throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
+					if (!mappingOpened) {
+						restoreState(state, beforeKey);
+						addMappingEvent(state, beforeKey.position, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+						mappingOpened = true;
+						parseNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true);
+						ch = state.input.charCodeAt(state.position);
+						while (isWhiteSpace(ch)) ch = state.input.charCodeAt(++state.position);
+						state.position++;
+					}
+					detected = true;
+					atExplicitKey = false;
+					pendingExplicitKey = false;
+				} else if (detected) throwError(state, "expected ':' after a mapping key");
+				else {
+					if (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1) {
+						restoreState(state, beforeKey);
+						return false;
+					}
+					return true;
+				}
+			} else if (detected) throwError(state, "can not read a block mapping entry; a multiline key may not be an implicit key");
+			else {
+				if (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1) {
+					restoreState(state, beforeKey);
+					return false;
+				}
+				return true;
+			}
+		}
+		if (parseNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, pendingExplicitKey)) pendingExplicitKey = false;
+		if (!atExplicitKey) {
+			if (pendingExplicitKey) {
+				addEmptyScalarEvent(state);
+				pendingExplicitKey = false;
+			}
+		}
+		skipSeparationSpace(state, true);
+		ch = state.input.charCodeAt(state.position);
+		if ((state.line === entryLine || state.lineIndent > nodeIndent) && ch !== 0) throwError(state, "bad indentation of a mapping entry");
+		else if (state.lineIndent < nodeIndent) break;
+	}
+	if (!detected) return false;
+	if (atExplicitKey) addEmptyScalarEvent(state);
+	if (mappingOpened) addPopEvent(state);
+	return true;
+}
+function parseNode(state, parentIndent, nodeContext, allowToSeek, allowCompact, allowPropertyMapping = true) {
+	if (state.depth >= state.maxDepth) throwError(state, `nesting exceeded maxDepth (${state.maxDepth})`);
+	state.depth++;
+	let indentStatus = 1;
+	let atNewLine = false;
+	let hasContent = false;
+	let propertyStart = null;
+	const props = emptyProperties();
+	let allowBlockScalars = nodeContext === CONTEXT_BLOCK_OUT || nodeContext === CONTEXT_BLOCK_IN;
+	let allowBlockCollections = allowBlockScalars;
+	const allowBlockStyles = allowBlockScalars;
+	if (allowToSeek && skipSeparationSpace(state, true)) {
+		atNewLine = true;
+		if (state.lineIndent > parentIndent) indentStatus = 1;
+		else if (state.lineIndent === parentIndent) indentStatus = 0;
+		else indentStatus = -1;
+	}
+	if (indentStatus === 1) while (true) {
+		const ch = state.input.charCodeAt(state.position);
+		const propertyState = snapshotState(state);
+		if (atNewLine && indentStatus !== 1 && (ch === 33 || ch === 38)) break;
+		if (atNewLine && allowBlockStyles && (props.tagStart !== NO_RANGE$1 || props.anchorStart !== NO_RANGE$1) && (ch === 33 || ch === 38)) {
+			const fallbackState = snapshotState(state);
+			const flowIndent = parentIndent + 1;
+			if (readBlockMapping(state, state.position - state.lineStart, flowIndent, props) && state.events[fallbackState.eventsLength]?.type === 3) {
+				state.depth--;
+				return true;
+			}
+			restoreState(state, fallbackState);
+		}
+		if (atNewLine && (ch === 33 && props.tagStart !== NO_RANGE$1 || ch === 38 && props.anchorStart !== NO_RANGE$1)) break;
+		if (!readTagProperty(state, props, nodeContext === CONTEXT_FLOW_IN) && !readAnchorProperty(state, props)) break;
+		if (propertyStart === null) propertyStart = propertyState;
+		if (skipSeparationSpace(state, true)) {
+			atNewLine = true;
+			allowBlockCollections = allowBlockStyles;
+			if (state.lineIndent > parentIndent) indentStatus = 1;
+			else if (state.lineIndent === parentIndent) indentStatus = 0;
+			else indentStatus = -1;
+		} else allowBlockCollections = false;
+	}
+	if (allowBlockCollections) allowBlockCollections = atNewLine || allowCompact;
+	if (indentStatus === 1 || nodeContext === CONTEXT_BLOCK_OUT) {
+		const flowIndent = nodeContext === CONTEXT_FLOW_IN || nodeContext === CONTEXT_FLOW_OUT ? parentIndent : parentIndent + 1;
+		const blockIndent = state.position - state.lineStart;
+		if (indentStatus === 1) if (allowBlockCollections && (readBlockSequence(state, blockIndent, props) || readBlockMapping(state, blockIndent, flowIndent, props)) || readFlowCollection(state, flowIndent, props)) hasContent = true;
+		else {
+			const ch = state.input.charCodeAt(state.position);
+			if (propertyStart !== null && allowPropertyMapping && allowBlockStyles && !allowBlockCollections && ch !== 124 && ch !== 62) {
+				const fallbackState = snapshotState(state);
+				const propertyIndent = propertyStart.position - propertyStart.lineStart;
+				restoreState(state, propertyStart);
+				if (readBlockMapping(state, propertyIndent, flowIndent, emptyProperties()) && state.events[fallbackState.eventsLength]?.type === 3) hasContent = true;
+				else restoreState(state, fallbackState);
+			}
+			if (!hasContent && (allowBlockScalars && readBlockScalar(state, flowIndent, props) || readSingleQuotedScalar(state, flowIndent, props) || readDoubleQuotedScalar(state, flowIndent, props) || readAlias(state, props) || readPlainScalar(state, flowIndent, nodeContext, props))) hasContent = true;
+		}
+		else if (indentStatus === 0) hasContent = allowBlockCollections && readBlockSequence(state, blockIndent, props);
+	}
+	allowBlockScalars = allowBlockScalars && !hasContent;
+	if (!hasContent && (props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1 || allowBlockScalars)) {
+		addScalarEvent(state, NO_RANGE$1, NO_RANGE$1, props.anchorStart, props.anchorEnd, props.tagStart, props.tagEnd, 1);
+		hasContent = true;
+	}
+	state.depth--;
+	return hasContent || props.anchorStart !== NO_RANGE$1 || props.tagStart !== NO_RANGE$1;
+}
+function readDirective(state) {
+	if (state.lineIndent > 0 || state.input.charCodeAt(state.position) !== 37) return false;
+	state.position++;
+	const nameStart = state.position;
+	while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position))) state.position++;
+	const name = state.input.slice(nameStart, state.position);
+	const args = [];
+	if (name.length === 0) throwError(state, "directive name must not be less than one character in length");
+	while (state.input.charCodeAt(state.position) !== 0 && !isEol(state.input.charCodeAt(state.position))) {
+		while (isWhiteSpace(state.input.charCodeAt(state.position))) state.position++;
+		if (state.input.charCodeAt(state.position) === 35 || isEol(state.input.charCodeAt(state.position)) || state.input.charCodeAt(state.position) === 0) break;
+		const start = state.position;
+		while (state.input.charCodeAt(state.position) !== 0 && !isWsOrEol(state.input.charCodeAt(state.position))) state.position++;
+		args.push(state.input.slice(start, state.position));
+	}
+	if (isEol(state.input.charCodeAt(state.position))) consumeLineBreak(state);
+	if (name === "YAML") {
+		if (state.directives.some((directive) => directive.kind === "yaml")) throwError(state, "duplication of %YAML directive");
+		if (args.length !== 1) throwError(state, "YAML directive accepts exactly one argument");
+		const match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+		if (match === null) throwError(state, "ill-formed argument of the YAML directive");
+		if (parseInt(match[1], 10) !== 1) throwError(state, "unacceptable YAML version of the document");
+		state.directives.push({
+			kind: "yaml",
+			version: args[0]
+		});
+	} else if (name === "TAG") {
+		if (args.length !== 2) throwError(state, "TAG directive accepts exactly two arguments");
+		const [handle, prefix] = args;
+		if (!PATTERN_TAG_HANDLE.test(handle)) throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
+		if (HAS_OWN.call(state.tagHandlers, handle)) throwError(state, `there is a previously declared suffix for "${handle}" tag handle`);
+		if (!PATTERN_TAG_PREFIX.test(prefix)) throwError(state, "ill-formed tag prefix (second argument) of the TAG directive");
+		state.tagHandlers[handle] = prefix;
+		state.directives.push({
+			kind: "tag",
+			handle,
+			prefix
+		});
+	}
+	return true;
+}
+function readDocument(state) {
+	state.directives = [];
+	state.tagHandlers = Object.create(null);
+	let hasDirectives = false;
+	skipSeparationSpace(state, true);
+	while (readDirective(state)) {
+		hasDirectives = true;
+		skipSeparationSpace(state, true);
+	}
+	let explicitStart = false;
+	let explicitEnd = false;
+	let allowCompact = true;
+	if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45 && isWsOrEolOrEnd(state.input.charCodeAt(state.position + 3))) {
+		explicitStart = true;
+		const markerLine = state.line;
+		state.position += 3;
+		skipSeparationSpace(state, true);
+		allowCompact = state.line > markerLine;
+	} else if (hasDirectives) throwError(state, "directives end mark is expected");
+	const documentEventIndex = state.events.length;
+	if (!explicitStart && state.position === state.lineStart && state.input.charCodeAt(state.position) === 46 && testDocumentSeparator(state)) {
+		state.position += 3;
+		skipSeparationSpace(state, true);
+		return;
+	}
+	addDocumentEvent(state, explicitStart, false);
+	if (!parseNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, allowCompact, allowCompact)) addEmptyScalarEvent(state);
+	skipSeparationSpace(state, true);
+	if (state.position === state.lineStart && testDocumentSeparator(state)) {
+		explicitEnd = state.input.charCodeAt(state.position) === 46;
+		if (explicitEnd) {
+			const markerLine = state.line;
+			state.position += 3;
+			skipSeparationSpace(state, true);
+			if (state.line === markerLine && state.position < state.length) throwError(state, "end of the stream or a document separator is expected");
+		}
+	}
+	const documentEvent = state.events[documentEventIndex];
+	if (documentEvent?.type === 1) documentEvent.explicitEnd = explicitEnd;
+	addPopEvent(state);
+	if (!explicitEnd && state.position < state.length && !(state.position === state.lineStart && testDocumentSeparator(state))) throwError(state, "end of the stream or a document separator is expected");
+}
+function parseEvents(input, options) {
+	const length = input.length;
+	const state = {
+		...DEFAULT_PARSER_OPTIONS,
+		...options,
+		input: `${input}\0`,
+		length,
+		position: 0,
+		line: 0,
+		lineStart: 0,
+		lineIndent: 0,
+		firstTabInLine: -1,
+		depth: 0,
+		directives: [],
+		tagHandlers: Object.create(null),
+		events: []
+	};
+	const nullpos = input.indexOf("\0");
+	if (nullpos !== -1) throwErrorAt(input, nullpos, "null byte is not allowed in input", state.filename);
+	if (state.input.charCodeAt(state.position) === 65279) state.position++;
+	while (state.position < state.length) {
+		skipSeparationSpace(state, true);
+		if (state.position >= state.length) break;
+		const documentStart = state.position;
+		readDocument(state);
+		if (state.position === documentStart)
+ /* c8 ignore next */
+		throwError(state, "can not read a document");
+	}
+	return state.events;
+}
+//#endregion
+//#region src/load.ts
+var DEFAULT_LOAD_OPTIONS = {
+	...DEFAULT_PARSER_OPTIONS,
+	...DEFAULT_CONSTRUCTOR_OPTIONS
+};
+function loadDocuments(input, options = {}) {
+	const opts = {
+		...DEFAULT_LOAD_OPTIONS,
+		...options
+	};
+	const source = String(input);
+	const PARSER_OPT_KEYS = Object.keys(DEFAULT_PARSER_OPTIONS);
+	const CONSTRUCTOR_OPT_KEYS = Object.keys(DEFAULT_CONSTRUCTOR_OPTIONS);
+	return constructFromEvents(parseEvents(source, pick(opts, PARSER_OPT_KEYS)), {
+		...pick(opts, CONSTRUCTOR_OPT_KEYS),
+		source
+	});
+}
+function loadAll(input, iteratorOrOptions, options) {
+	let iterator = null;
+	if (typeof iteratorOrOptions === "function") iterator = iteratorOrOptions;
+	else if (iteratorOrOptions !== null && typeof iteratorOrOptions === "object") options = iteratorOrOptions;
+	const documents = loadDocuments(input, options);
+	if (iterator === null) return documents;
+	for (const document of documents) iterator(document);
+}
+function load(input, options) {
+	const documents = loadDocuments(input, options);
+	if (documents.length === 0) throw new YAMLException("expected a document, but the input is empty");
+	if (documents.length === 1) return documents[0];
+	throw new YAMLException("expected a single document in the stream, but found more");
+}
+//#endregion
+//#region src/ast/nodes.ts
+var Style = class {
+	tagged = false;
+	flow = false;
+	singleQuoted = false;
+	doubleQuoted = false;
+	literal = false;
+	folded = false;
+};
+//#endregion
+//#region src/ast/from_js.ts
+var INVALID = Symbol("INVALID");
+function buildRepresentTypes(schema) {
+	const defaultTags = new Set([
+		schema.defaultScalarTag,
+		schema.defaultSequenceTag,
+		schema.defaultMappingTag
+	].filter((t) => t !== void 0));
+	const implicitScalars = schema.implicitScalarTags;
+	const explicitTags = schema.tags.filter((t) => !(t.nodeKind === "scalar" && t.implicit) && !defaultTags.has(t));
+	const defaultTagsLast = schema.tags.filter((t) => defaultTags.has(t));
+	return [
+		...implicitScalars.map((tag) => ({
+			tag,
+			implicitTag: true
+		})),
+		...explicitTags.map((tag) => ({
+			tag,
+			implicitTag: false
+		})),
+		...defaultTagsLast.map((tag) => ({
+			tag,
+			implicitTag: true
+		}))
+	];
+}
+function matchTag(state, object) {
+	for (let index = 0, length = state.representTypes.length; index < length; index += 1) {
+		const { tag, implicitTag } = state.representTypes[index];
+		if (tag.identify && tag.identify(object)) {
+			let tagName;
+			if (tag.matchByTagPrefix && tag.representTagName) tagName = tag.representTagName(object);
+			else tagName = tag.tagName;
+			return {
+				tag,
+				tagName,
+				implicitTag
+			};
+		}
+	}
+	return null;
+}
+function build(state, object) {
+	if (!state.noRefs && object !== null && typeof object === "object") {
+		const existing = state.refs.get(object);
+		if (existing) {
+			if (existing.anchor === void 0) existing.anchor = `ref_${state.refCounter++}`;
+			return {
+				kind: "alias",
+				tag: "",
+				style: new Style(),
+				anchor: existing.anchor
+			};
+		}
+	}
+	const matched = matchTag(state, object);
+	if (!matched) {
+		if (object === void 0) return INVALID;
+		if (state.skipInvalid) return INVALID;
+		throw new YAMLException(`unacceptable kind of an object to dump ${Object.prototype.toString.call(object)}`);
+	}
+	const { tag, tagName, implicitTag } = matched;
+	const nodeTagName = implicitTag ? tagName : tagNameShort(tagName);
+	if (tag.nodeKind === "scalar") {
+		const style = new Style();
+		style.tagged = !implicitTag;
+		return {
+			kind: "scalar",
+			tag: nodeTagName,
+			style,
+			value: tag.represent(object)
+		};
+	}
+	if (tag.nodeKind === "sequence") {
+		const container = tag.represent(object);
+		const style = new Style();
+		style.tagged = !implicitTag;
+		const node = {
+			kind: "sequence",
+			tag: nodeTagName,
+			style,
+			items: []
+		};
+		if (!state.noRefs) state.refs.set(object, node);
+		for (let index = 0, length = container.length; index < length; index += 1) {
+			let item = build(state, container[index]);
+			if (item === INVALID && container[index] === void 0) item = build(state, null);
+			if (item === INVALID) continue;
+			node.items.push(item);
+		}
+		return node;
+	}
+	const map = tag.represent(object);
+	const style = new Style();
+	style.tagged = !implicitTag;
+	const node = {
+		kind: "mapping",
+		tag: nodeTagName,
+		style,
+		items: []
+	};
+	if (!state.noRefs) state.refs.set(object, node);
+	for (const [objectKey, objectValue] of map) {
+		const key = build(state, objectKey);
+		if (key === INVALID) continue;
+		const value = build(state, objectValue);
+		if (value === INVALID) continue;
+		node.items.push({
+			key,
+			value
+		});
+	}
+	return node;
+}
+function jsToAst(input, schema, options = {}) {
+	const root = build({
+		representTypes: buildRepresentTypes(schema),
+		noRefs: options.noRefs ?? false,
+		skipInvalid: options.skipInvalid ?? false,
+		refs: /* @__PURE__ */ new Map(),
+		refCounter: 0
+	}, input);
+	return [{
+		contents: root === INVALID ? null : root,
+		directives: []
+	}];
+}
+//#endregion
+//#region src/ast/visit.ts
+var VISIT_BREAK = Symbol("visit:break");
+var VISIT_SKIP = Symbol("visit:skip");
+function visitNode(node, visitor, ctx) {
+	const control = visitor(node, ctx);
+	if (control === VISIT_BREAK) return true;
+	if (control === VISIT_SKIP) return false;
+	const depth = ctx.depth + 1;
+	switch (node.kind) {
+		case "sequence":
+			for (const item of node.items) if (visitNode(item, visitor, {
+				depth,
+				parent: node,
+				isKey: false
+			})) return true;
+			break;
+		case "mapping":
+			for (const { key, value } of node.items) {
+				if (visitNode(key, visitor, {
+					depth,
+					parent: node,
+					isKey: true
+				})) return true;
+				if (visitNode(value, visitor, {
+					depth,
+					parent: node,
+					isKey: false
+				})) return true;
+			}
+			break;
+	}
+	return false;
+}
+function visit(documents, visitor) {
+	for (const doc of documents) if (doc.contents && visitNode(doc.contents, visitor, {
+		depth: 0,
+		parent: null,
+		isKey: false
+	})) return;
+}
+//#endregion
+//#region src/ast/presenter.ts
+var CHAR_BOM = 65279;
+var CHAR_TAB = 9;
+var CHAR_LINE_FEED = 10;
+var CHAR_CARRIAGE_RETURN = 13;
+var CHAR_SPACE = 32;
+var CHAR_EXCLAMATION = 33;
+var CHAR_DOUBLE_QUOTE = 34;
+var CHAR_SHARP = 35;
+var CHAR_PERCENT = 37;
+var CHAR_AMPERSAND = 38;
+var CHAR_SINGLE_QUOTE = 39;
+var CHAR_ASTERISK = 42;
+var CHAR_COMMA = 44;
+var CHAR_MINUS = 45;
+var CHAR_COLON = 58;
+var CHAR_EQUALS = 61;
+var CHAR_GREATER_THAN = 62;
+var CHAR_QUESTION = 63;
+var CHAR_COMMERCIAL_AT = 64;
+var CHAR_LEFT_SQUARE_BRACKET = 91;
+var CHAR_RIGHT_SQUARE_BRACKET = 93;
+var CHAR_GRAVE_ACCENT = 96;
+var CHAR_LEFT_CURLY_BRACKET = 123;
+var CHAR_VERTICAL_LINE = 124;
+var CHAR_RIGHT_CURLY_BRACKET = 125;
+var ESCAPE_SEQUENCES = {};
+ESCAPE_SEQUENCES[0] = "\\0";
+ESCAPE_SEQUENCES[7] = "\\a";
+ESCAPE_SEQUENCES[8] = "\\b";
+ESCAPE_SEQUENCES[9] = "\\t";
+ESCAPE_SEQUENCES[10] = "\\n";
+ESCAPE_SEQUENCES[11] = "\\v";
+ESCAPE_SEQUENCES[12] = "\\f";
+ESCAPE_SEQUENCES[13] = "\\r";
+ESCAPE_SEQUENCES[27] = "\\e";
+ESCAPE_SEQUENCES[34] = "\\\"";
+ESCAPE_SEQUENCES[92] = "\\\\";
+ESCAPE_SEQUENCES[133] = "\\N";
+ESCAPE_SEQUENCES[160] = "\\_";
+ESCAPE_SEQUENCES[8232] = "\\L";
+ESCAPE_SEQUENCES[8233] = "\\P";
+var DEFAULT_PRESENTER_OPTIONS = {
+	indent: 2,
+	seqNoIndent: false,
+	seqInlineFirst: true,
+	sortKeys: false,
+	lineWidth: 80,
+	flowBracketPadding: false,
+	flowSkipCommaSpace: false,
+	flowSkipColonSpace: false,
+	quoteFlowKeys: false,
+	quoteStyle: "single",
+	forceQuotes: false,
+	tagBeforeAnchor: false
+};
+function nodeTagShort(node) {
+	return node.style.tagged ? node.tag : tagNameShort(node.tag);
+}
+function createPresenterState(options) {
+	const opts = {
+		...DEFAULT_PRESENTER_OPTIONS,
+		...options
+	};
+	return {
+		...opts,
+		defaultScalarTagName: opts.schema.defaultScalarTag.tagName,
+		implicitResolvers: opts.schema.implicitScalarTags
+	};
+}
+function encodeNonPrintable(character) {
+	const string = character.toString(16).toUpperCase();
+	const handle = character <= 255 ? "x" : "u";
+	const length = character <= 255 ? 2 : 4;
+	return `\\${handle}${"0".repeat(length - string.length)}${string}`;
+}
+function indentString(string, spaces) {
+	const ind = " ".repeat(spaces);
+	let position = 0;
+	let result = "";
+	const length = string.length;
+	while (position < length) {
+		let line;
+		const next = string.indexOf("\n", position);
+		if (next === -1) {
+			line = string.slice(position);
+			position = length;
+		} else {
+			line = string.slice(position, next + 1);
+			position = next + 1;
+		}
+		if (line.length && line !== "\n") result += ind;
+		result += line;
+	}
+	return result;
+}
+function generateNextLine(state, level) {
+	return `\n${" ".repeat(state.indent * level)}`;
+}
+function scalarLayout(state, level) {
+	const indent = state.indent * Math.max(1, level);
+	return {
+		indent,
+		blockIndent: level === 0 ? state.indent + 1 : state.indent,
+		lineWidth: state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent)
+	};
+}
+function resolveImplicitTag(state, str) {
+	for (let index = 0, length = state.implicitResolvers.length; index < length; index += 1) {
+		const tagDefinition = state.implicitResolvers[index];
+		if (tagDefinition.resolve(str, false, tagDefinition.tagName) !== NOT_RESOLVED) return tagDefinition.tagName;
+	}
+	return state.defaultScalarTagName;
+}
+function isWhitespace(c) {
+	return c === CHAR_SPACE || c === CHAR_TAB;
+}
+function startsWithDocumentSeparator(string) {
+	const marker = string.charCodeAt(0);
+	if (marker !== CHAR_MINUS && marker !== 46 || string.charCodeAt(1) !== marker || string.charCodeAt(2) !== marker) return false;
+	if (string.length === 3) return true;
+	const following = string.charCodeAt(3);
+	return isWhitespace(following) || following === CHAR_CARRIAGE_RETURN || following === CHAR_LINE_FEED;
+}
+function isPrintable(c) {
+	return c >= 32 && c <= 126 || c >= 161 && c <= 55295 && c !== 8232 && c !== 8233 || c >= 57344 && c <= 65533 && c !== CHAR_BOM || c >= 65536 && c <= 1114111;
+}
+function isNsCharOrWhitespace(c) {
+	return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
+}
+function isPlainSafe(c, prev, inblock) {
+	const cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+	const cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+	return (inblock ? cIsNsCharOrWhitespace : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar && (inblock || c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET);
+}
+function isPlainSafeFirst(c) {
+	return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
+}
+function isPlainSafeAtStart(string, inblock) {
+	const first = codePointAt(string, 0);
+	if (isPlainSafeFirst(first)) return true;
+	if (string.length > 1 && (first === CHAR_MINUS || first === CHAR_QUESTION || first === CHAR_COLON)) {
+		const second = codePointAt(string, 1);
+		return !isWhitespace(second) && isPlainSafe(second, first, inblock);
+	}
+	return false;
+}
+function isPlainSafeLast(c) {
+	return !isWhitespace(c) && c !== CHAR_COLON;
+}
+function codePointAt(string, pos) {
+	const first = string.charCodeAt(pos);
+	let second;
+	if (first >= 55296 && first <= 56319 && pos + 1 < string.length) {
+		second = string.charCodeAt(pos + 1);
+		if (second >= 56320 && second <= 57343) return (first - 55296) * 1024 + second - 56320 + 65536;
+	}
+	return first;
+}
+function needIndentIndicator(string) {
+	return /^\n* /.test(string);
+}
+var STYLE_PLAIN = 1;
+var STYLE_SINGLE = 2;
+var STYLE_LITERAL = 3;
+var STYLE_FOLDED = 4;
+var STYLE_DOUBLE = 5;
+function chooseScalarStyle(state, string, layout, singleLineOnly, forceQuote, inblock) {
+	const { blockIndent, lineWidth } = layout;
+	let i;
+	let char = 0;
+	let prevChar = -1;
+	let hasLineBreak = false;
+	let hasFoldableLine = false;
+	const shouldTrackWidth = lineWidth !== -1;
+	let previousLineBreak = -1;
+	let plain = !startsWithDocumentSeparator(string) && isPlainSafeAtStart(string, inblock) && isPlainSafeLast(codePointAt(string, string.length - 1));
+	if (singleLineOnly || forceQuote) for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+		char = codePointAt(string, i);
+		if (!isPrintable(char)) return STYLE_DOUBLE;
+		plain = plain && isPlainSafe(char, prevChar, inblock);
+		prevChar = char;
+	}
+	else {
+		for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+			char = codePointAt(string, i);
+			if (char === CHAR_LINE_FEED) {
+				hasLineBreak = true;
+				if (shouldTrackWidth) {
+					hasFoldableLine = hasFoldableLine || i - previousLineBreak - 1 > lineWidth && !isMoreIndented(string[previousLineBreak + 1]);
+					previousLineBreak = i;
+				}
+			} else if (!isPrintable(char)) return STYLE_DOUBLE;
+			plain = plain && isPlainSafe(char, prevChar, inblock);
+			prevChar = char;
+		}
+		hasFoldableLine = hasFoldableLine || shouldTrackWidth && i - previousLineBreak - 1 > lineWidth && !isMoreIndented(string[previousLineBreak + 1]);
+	}
+	if (!hasLineBreak && !hasFoldableLine) {
+		if (plain && !forceQuote) return STYLE_PLAIN;
+		return state.quoteStyle === "double" ? STYLE_DOUBLE : STYLE_SINGLE;
+	}
+	if (blockIndent > 9 && needIndentIndicator(string)) return STYLE_DOUBLE;
+	return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+}
+function renderScalarStyle(string, style, layout) {
+	const { indent, blockIndent, lineWidth } = layout;
+	switch (style) {
+		case STYLE_PLAIN: return encodeFlowBreaks(string, indent);
+		case STYLE_SINGLE: return `'${encodeFlowBreaks(string, indent).replace(/'/g, "''")}'`;
+		case STYLE_LITERAL: return "|" + blockHeader(string, blockIndent) + dropEndingNewline(indentString(string, indent));
+		case STYLE_FOLDED: return ">" + blockHeader(string, blockIndent) + dropEndingNewline(indentString(foldBlockScalar(string, lineWidth), indent));
+		case STYLE_DOUBLE: return `"${escapeString(string)}"`;
+	}
+}
+function resolveScalarStyle(state, node, layout, iskey, inblock) {
+	const singleLineOnly = iskey || !inblock;
+	if (node.style.singleQuoted) return STYLE_SINGLE;
+	if (node.style.doubleQuoted) return STYLE_DOUBLE;
+	if (!singleLineOnly) {
+		if (node.style.literal) return STYLE_LITERAL;
+		if (node.style.folded) return STYLE_FOLDED;
+	}
+	const string = node.value;
+	if (string.length === 0) {
+		if (node.style.tagged || resolveImplicitTag(state, string) === node.tag) return STYLE_PLAIN;
+		return state.quoteStyle === "double" ? STYLE_DOUBLE : STYLE_SINGLE;
+	}
+	const style = chooseScalarStyle(state, string, layout, singleLineOnly, state.forceQuotes && !iskey, inblock);
+	if (style === STYLE_PLAIN && !node.style.tagged && resolveImplicitTag(state, string) !== node.tag) return state.quoteStyle === "double" ? STYLE_DOUBLE : STYLE_SINGLE;
+	return style;
+}
+function blockHeader(string, indentPerLevel) {
+	const indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
+	const clip = string[string.length - 1] === "\n";
+	return `${indentIndicator}${clip && (string[string.length - 2] === "\n" || string === "\n") ? "+" : clip ? "" : "-"}\n`;
+}
+function encodeFlowBreaks(string, indent) {
+	let nextLF = string.indexOf("\n");
+	if (nextLF === -1) return string;
+	const pad = " ".repeat(indent);
+	let result = string.slice(0, nextLF);
+	const lineRe = /(\n+)([^\n]*)/g;
+	lineRe.lastIndex = nextLF;
+	let match;
+	while (match = lineRe.exec(string)) {
+		const breaks = match[1].length;
+		const line = match[2];
+		result += "\n".repeat(breaks + 1) + pad + line;
+	}
+	return result;
+}
+function dropEndingNewline(string) {
+	return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
+}
+function isMoreIndented(char) {
+	return char === " " || char === "	";
+}
+function foldBlockScalar(string, width) {
+	const lineRe = /(\n+)([^\n]*)/g;
+	let nextLF = string.indexOf("\n");
+	if (nextLF === -1) nextLF = string.length;
+	lineRe.lastIndex = nextLF;
+	let result = foldLine(string.slice(0, nextLF), width);
+	let prevMoreIndented = string[0] === "\n" || isMoreIndented(string[0]);
+	let moreIndented;
+	let match;
+	while (match = lineRe.exec(string)) {
+		const prefix = match[1];
+		const line = match[2];
+		moreIndented = line !== "" && isMoreIndented(line[0]);
+		result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
+		prevMoreIndented = moreIndented;
+	}
+	return result;
+}
+function foldLine(line, width) {
+	if (line === "" || isMoreIndented(line[0])) return line;
+	const breakRe = / [^ \t]/g;
+	let match;
+	let start = 0;
+	let end;
+	let curr = 0;
+	let next = 0;
+	let result = "";
+	while (match = breakRe.exec(line)) {
+		next = match.index;
+		if (next - start > width) {
+			end = curr > start ? curr : next;
+			result += `\n${line.slice(start, end)}`;
+			start = end + 1;
+		}
+		curr = next;
+	}
+	result += "\n";
+	if (line.length - start > width && curr > start) result += `${line.slice(start, curr)}\n${line.slice(curr + 1)}`;
+	else result += line.slice(start);
+	return result.slice(1);
+}
+function escapeString(string) {
+	let result = "";
+	let char = 0;
+	for (let i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+		char = codePointAt(string, i);
+		const escapeSeq = ESCAPE_SEQUENCES[char];
+		if (escapeSeq) {
+			result += escapeSeq;
+			continue;
+		}
+		if (isPrintable(char)) {
+			result += string[i];
+			if (char >= 65536) result += string[i + 1];
+			continue;
+		}
+		result += encodeNonPrintable(char);
+	}
+	return result;
+}
+function writeFlowSequence(state, level, node) {
+	let result = "";
+	for (let index = 0, length = node.items.length; index < length; index += 1) {
+		const item = writeNode(state, level, node.items[index], {});
+		if (result !== "") result += `,${!state.flowSkipCommaSpace ? " " : ""}`;
+		result += item;
+	}
+	const pad = state.flowBracketPadding && result !== "" ? " " : "";
+	return `[${pad}${result}${pad}]`;
+}
+function writeBlockSequence(state, level, node, compact) {
+	let result = "";
+	for (let index = 0, length = node.items.length; index < length; index += 1) {
+		const item = writeNode(state, level + 1, node.items[index], {
+			block: true,
+			compact: state.seqInlineFirst,
+			isblockseq: true
+		});
+		if (!compact || result !== "") result += generateNextLine(state, level);
+		if (item === "" || CHAR_LINE_FEED === item.charCodeAt(0)) result += "-";
+		else result += "- ";
+		result += item;
+	}
+	return result;
+}
+function writeFlowMapping(state, level, node) {
+	let result = "";
+	const items = sortMappingItems(state, node.items);
+	for (const { key, value } of items) {
+		let pairBuffer = "";
+		if (result !== "") pairBuffer += `,${!state.flowSkipCommaSpace ? " " : ""}`;
+		const keyText = writeNode(state, level, key, { iskey: true });
+		const explicitPair = keyText.length > 1024;
+		if (explicitPair) pairBuffer += "? ";
+		else if (state.quoteFlowKeys) pairBuffer += "\"";
+		const valueText = writeNode(state, level, value, {});
+		const sep = state.flowSkipColonSpace || valueText === "" ? "" : " ";
+		pairBuffer += `${keyText}${state.quoteFlowKeys && !explicitPair ? "\"" : ""}:${sep}${valueText}`;
+		result += pairBuffer;
+	}
+	const pad = state.flowBracketPadding && result !== "" ? " " : "";
+	return `{${pad}${result}${pad}}`;
+}
+function sortKeyValue(key) {
+	return key.kind === "scalar" ? key.value : key;
+}
+function sortMappingItems(state, items) {
+	if (!state.sortKeys) return items;
+	const copy = items.slice();
+	if (state.sortKeys === true) copy.sort((a, b) => {
+		const x = sortKeyValue(a.key);
+		const y = sortKeyValue(b.key);
+		if (x < y) return -1;
+		if (x > y) return 1;
+		return 0;
+	});
+	else {
+		const fn = state.sortKeys;
+		copy.sort((a, b) => fn(sortKeyValue(a.key), sortKeyValue(b.key)));
+	}
+	return copy;
+}
+function writeBlockMapping(state, level, node, compact) {
+	let result = "";
+	const items = sortMappingItems(state, node.items);
+	for (let index = 0, length = items.length; index < length; index += 1) {
+		let pairBuffer = "";
+		if (!compact || result !== "") pairBuffer += generateNextLine(state, level);
+		const { key, value } = items[index];
+		const keyIsBlock = (key.kind === "mapping" || key.kind === "sequence") && !key.style.flow && key.items.length !== 0 || key.kind === "scalar" && (key.style.literal || key.style.folded);
+		const keyText = keyIsBlock ? writeNode(state, level + 1, key, {
+			block: true,
+			compact: true,
+			isblockseq: !cannotBeCompact(state, key, level + 1)
+		}) : writeNode(state, level + 1, key, {
+			block: true,
+			compact: true,
+			iskey: true
+		});
+		const keyHasLineBreak = key.kind === "scalar" && key.value.indexOf("\n") !== -1;
+		const explicitPair = keyIsBlock || keyHasLineBreak || keyText.length > 1024;
+		if (explicitPair) if (keyText && CHAR_LINE_FEED === keyText.charCodeAt(0)) pairBuffer += "?";
+		else pairBuffer += "? ";
+		pairBuffer += keyText;
+		if (explicitPair) pairBuffer += generateNextLine(state, level);
+		const valueText = writeNode(state, level + 1, value, {
+			block: true,
+			compact: explicitPair,
+			isblockseq: explicitPair && !cannotBeCompact(state, value, level + 1)
+		});
+		const keyIsBareProps = key.kind === "scalar" && key.value === "" && keyText !== "" && keyText.charCodeAt(keyText.length - 1) !== CHAR_SINGLE_QUOTE && keyText.charCodeAt(keyText.length - 1) !== CHAR_DOUBLE_QUOTE;
+		const keyColonSep = !explicitPair && (key.kind === "alias" || keyIsBareProps) ? " " : "";
+		if (valueText === "" || CHAR_LINE_FEED === valueText.charCodeAt(0)) pairBuffer += `${keyColonSep}:`;
+		else pairBuffer += `${keyColonSep}: `;
+		pairBuffer += valueText;
+		result += pairBuffer;
+	}
+	return result;
+}
+function cannotBeCompact(state, node, level) {
+	return node.style.tagged || node.anchor !== void 0 || state.indent < 2 && level > 0;
+}
+function writeNode(state, level, node, ctx) {
+	if (node.kind === "alias") return `*${node.anchor}`;
+	const { block = false, iskey = false, isblockseq = false } = ctx;
+	let compact = ctx.compact ?? false;
+	const hasAnchor = node.anchor !== void 0;
+	if (cannotBeCompact(state, node, level)) compact = false;
+	let body;
+	let shouldPrintTag = node.style.tagged;
+	const useBlockCollection = block && (node.kind === "mapping" || node.kind === "sequence") && !node.style.flow && node.items.length !== 0;
+	if (node.kind === "mapping") if (useBlockCollection) body = writeBlockMapping(state, level, node, compact);
+	else body = writeFlowMapping(state, level, node);
+	else if (node.kind === "sequence") if (useBlockCollection) if (state.seqNoIndent && !isblockseq && level > 0) body = writeBlockSequence(state, level - 1, node, compact);
+	else body = writeBlockSequence(state, level, node, compact);
+	else body = writeFlowSequence(state, level, node);
+	else {
+		const layout = scalarLayout(state, level);
+		const style = resolveScalarStyle(state, node, layout, iskey, block);
+		body = renderScalarStyle(node.value, style, layout);
+		shouldPrintTag = node.style.tagged || style !== STYLE_PLAIN && node.tag !== state.defaultScalarTagName;
+	}
+	if (useBlockCollection && compact && level > 0 && state.indent > 2) body = `${" ".repeat(state.indent - 2)}${body}`;
+	if (shouldPrintTag || hasAnchor) {
+		const props = [];
+		const tag = shouldPrintTag ? nodeTagShort(node) : null;
+		const anchor = hasAnchor ? `&${node.anchor}` : null;
+		if (state.tagBeforeAnchor) {
+			if (tag !== null) props.push(tag);
+			if (anchor !== null) props.push(anchor);
+		} else {
+			if (anchor !== null) props.push(anchor);
+			if (tag !== null) props.push(tag);
+		}
+		const sep = body === "" || body.charCodeAt(0) === CHAR_LINE_FEED ? "" : " ";
+		body = `${props.join(" ")}${sep}${body}`;
+	}
+	return body;
+}
+function rootStartsOwnLine(node) {
+	return (node.kind === "sequence" || node.kind === "mapping") && !node.style.flow && node.items.length !== 0 && !node.style.tagged && node.anchor === void 0;
+}
+function isOpenEnded(node) {
+	let leaf = node;
+	while ((leaf.kind === "sequence" || leaf.kind === "mapping") && !leaf.style.flow && leaf.items.length !== 0) leaf = leaf.kind === "sequence" ? leaf.items[leaf.items.length - 1] : leaf.items[leaf.items.length - 1].value;
+	if (leaf.kind !== "scalar" || !(leaf.style.literal || leaf.style.folded)) return false;
+	const { value } = leaf;
+	return value.endsWith("\n\n") || value === "\n";
+}
+function writeDocumentDirectives(doc) {
+	let result = "";
+	for (const directive of doc.directives) {
+		if (directive.kind === "yaml") {
+			result += `%YAML ${directive.version}\n`;
+			continue;
+		}
+		const { handle, prefix } = directive;
+		result += `%TAG ${handle} ${prefix}\n`;
+	}
+	return result;
+}
+function present(documents, options) {
+	const state = createPresenterState(options);
+	let result = "";
+	let previousEnded = false;
+	for (let index = 0; index < documents.length; index += 1) {
+		const doc = documents[index];
+		const directives = writeDocumentDirectives(doc);
+		const hasDirectives = directives !== "";
+		const marker = doc.explicitStart || hasDirectives || index > 0 && !previousEnded;
+		result += directives;
+		if (doc.contents === null) {
+			if (marker) result += "---\n";
+		} else if (marker) {
+			const body = writeNode(state, 0, doc.contents, {
+				block: true,
+				compact: true
+			});
+			const sep = body === "" ? "" : hasDirectives || rootStartsOwnLine(doc.contents) ? "\n" : " ";
+			result += `---${sep}${body}\n`;
+		} else result += writeNode(state, 0, doc.contents, {
+			block: true,
+			compact: true
+		}) + "\n";
+		previousEnded = doc.explicitEnd || doc.contents !== null && isOpenEnded(doc.contents);
+		if (previousEnded) result += "...\n";
+	}
+	return result;
+}
+//#endregion
+//#region src/dump.ts
+var DEFAULT_DUMP_SCHEMA = YAML11_SCHEMA.withTags({
+	...intYaml11Tag,
+	resolve: (source, isExplicit, tagName) => {
+		const result = intYaml11Tag.resolve(source, isExplicit, tagName);
+		return result === NOT_RESOLVED ? intCoreTag.resolve(source, isExplicit, tagName) : result;
+	}
+}, {
+	...floatYaml11Tag,
+	resolve: (source, isExplicit, tagName) => {
+		const result = floatYaml11Tag.resolve(source, isExplicit, tagName);
+		return result === NOT_RESOLVED ? floatCoreTag.resolve(source, isExplicit, tagName) : result;
+	}
+});
+var DEFAULT_DUMP_OPTIONS = {
+	...DEFAULT_PRESENTER_OPTIONS,
+	schema: DEFAULT_DUMP_SCHEMA,
+	skipInvalid: false,
+	noRefs: false,
+	flowLevel: -1,
+	transform: () => {}
+};
+function dump(input, options = {}) {
+	const opts = {
+		...DEFAULT_DUMP_OPTIONS,
+		...options
+	};
+	const documents = jsToAst(input, opts.schema, {
+		noRefs: opts.noRefs,
+		skipInvalid: opts.skipInvalid
+	});
+	if (opts.flowLevel >= 0) visit(documents, (node, ctx) => {
+		if (ctx.depth < opts.flowLevel) return;
+		node.style.flow = true;
+		return VISIT_SKIP;
+	});
+	opts.transform(documents);
+	return present(documents, {
+		...pick(opts, Object.keys(DEFAULT_PRESENTER_OPTIONS)),
+		schema: opts.schema
+	});
+}
+//#endregion
+//#region src/ast/from_events.ts
+var NO_RANGE = -1;
+function eventPosition(event) {
+	if ("tagStart" in event && event.tagStart !== NO_RANGE) return event.tagStart;
+	if ("anchorStart" in event && event.anchorStart !== NO_RANGE) return event.anchorStart;
+	if ("valueStart" in event && event.valueStart !== NO_RANGE) return event.valueStart;
+	if ("start" in event) return event.start;
+	return 0;
+}
+function rawTag(state, event) {
+	return event.tagStart === NO_RANGE ? "" : state.source.slice(event.tagStart, event.tagEnd);
+}
+function anchorName(state, event) {
+	return event.anchorStart === NO_RANGE ? void 0 : state.source.slice(event.anchorStart, event.anchorEnd);
+}
+function implicitScalarTagName(state, source) {
+	const { schema } = state;
+	const candidates = schema.implicitScalarByFirstChar.get(source.charAt(0)) ?? schema.implicitScalarAnyFirstChar;
+	for (const tag of candidates) if (tag.resolve(source, false, tag.tagName) !== NOT_RESOLVED) return tag.tagName;
+	return schema.defaultScalarTag.tagName;
+}
+function buildScalar(state, event) {
+	const value = getScalarValue(state.source, event);
+	const raw = rawTag(state, event);
+	const style = new Style();
+	switch (event.style) {
+		case 2:
+			style.singleQuoted = true;
+			break;
+		case 3:
+			style.doubleQuoted = true;
+			break;
+		case 4:
+			style.literal = true;
+			break;
+		case 5:
+			style.folded = true;
+			break;
+	}
+	let tag;
+	if (raw !== "") {
+		style.tagged = true;
+		tag = raw;
+	} else if (event.style === 1) tag = implicitScalarTagName(state, value);
+	else tag = state.schema.defaultScalarTag.tagName;
+	return {
+		kind: "scalar",
+		tag,
+		style,
+		anchor: anchorName(state, event),
+		value
+	};
+}
+function buildCollection(state, event, defaultTagName) {
+	const raw = rawTag(state, event);
+	const style = new Style();
+	if (event.style === 2) style.flow = true;
+	let tag;
+	if (raw === "") tag = defaultTagName;
+	else {
+		tag = raw;
+		style.tagged = true;
+	}
+	return {
+		tag,
+		style,
+		anchor: anchorName(state, event)
+	};
+}
+function addNode(state, node) {
+	const frame = state.frames[state.frames.length - 1];
+	if (frame.kind === "document") frame.doc.contents = node;
+	else if (frame.kind === "sequence") frame.node.items.push(node);
+	else if (frame.key) {
+		frame.node.items.push({
+			key: frame.key,
+			value: node
+		});
+		frame.key = null;
+	} else frame.key = node;
+}
+function eventsToAst(events, options) {
+	const state = {
+		source: options.source,
+		schema: options.schema,
+		eventIndex: 0,
+		position: 0,
+		frames: [],
+		documents: []
+	};
+	while (state.eventIndex < events.length) {
+		const event = events[state.eventIndex++];
+		state.position = eventPosition(event);
+		switch (event.type) {
+			case 1: {
+				const doc = {
+					contents: null,
+					explicitStart: event.explicitStart,
+					explicitEnd: event.explicitEnd,
+					directives: event.directives
+				};
+				state.frames.push({
+					kind: "document",
+					doc
+				});
+				break;
+			}
+			case 4:
+				addNode(state, buildScalar(state, event));
+				break;
+			case 2: {
+				const { tag, style, anchor } = buildCollection(state, event, "tag:yaml.org,2002:seq");
+				const node = {
+					kind: "sequence",
+					tag,
+					style,
+					anchor,
+					items: []
+				};
+				state.frames.push({
+					kind: "sequence",
+					node
+				});
+				break;
+			}
+			case 3: {
+				const { tag, style, anchor } = buildCollection(state, event, "tag:yaml.org,2002:map");
+				const node = {
+					kind: "mapping",
+					tag,
+					style,
+					anchor,
+					items: []
+				};
+				state.frames.push({
+					kind: "mapping",
+					node,
+					key: null
+				});
+				break;
+			}
+			case 5: {
+				const name = state.source.slice(event.anchorStart, event.anchorEnd);
+				addNode(state, {
+					kind: "alias",
+					tag: "",
+					style: new Style(),
+					anchor: name
+				});
+				break;
+			}
+			case 6: {
+				const frame = state.frames.pop();
+				if (frame.kind === "mapping" && frame.key) throw new Error("incomplete mapping pair in event stream");
+				if (frame.kind === "document") state.documents.push(frame.doc);
+				else addNode(state, frame.node);
+				break;
+			}
+		}
+	}
+	return state.documents;
+}
+//#endregion
+export { CHOMPING_CLIP, CHOMPING_KEEP, CHOMPING_STRIP, COLLECTION_STYLE_BLOCK, COLLECTION_STYLE_FLOW, CORE_SCHEMA, EVENT_ALIAS, EVENT_DOCUMENT, EVENT_MAPPING, EVENT_POP, EVENT_SCALAR, EVENT_SEQUENCE, FAILSAFE_SCHEMA, JSON_SCHEMA, MERGE_KEY, NOT_RESOLVED, SCALAR_STYLE_DOUBLE_QUOTED, SCALAR_STYLE_FOLDED_BLOCK, SCALAR_STYLE_LITERAL_BLOCK, SCALAR_STYLE_PLAIN, SCALAR_STYLE_SINGLE_QUOTED, Schema, Style, VISIT_BREAK, VISIT_SKIP, YAML11_SCHEMA, YAMLException, binaryTag, boolCoreTag, boolJsonTag, boolYaml11Tag, constructFromEvents, defineMappingTag, defineScalarTag, defineSequenceTag, dump, eventsToAst, floatCoreTag, floatJsonTag, floatYaml11Tag, getScalarValue, intCoreTag, intJsonTag, intYaml11Tag, jsToAst, legacyMapTag, load, loadAll, mapTag, mergeTag, nullCoreTag, nullJsonTag, nullYaml11Tag, omapTag, pairsTag, parseEvents, present, realMapTag, seqTag, setTag, strTag, timestampTag, visit };
+
+//# sourceMappingURL=js-yaml.mjs.map

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/package.json
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/js-yaml/package.json
@@ -1,0 +1,91 @@
+{
+  "name": "js-yaml",
+  "version": "5.2.3",
+  "description": "YAML 1.2 parser and serializer",
+  "keywords": [
+    "yaml",
+    "parser",
+    "serializer",
+    "pyyaml"
+  ],
+  "author": "Vladimir Zapparov <dervus.grim@gmail.com>",
+  "contributors": [
+    "Aleksey V Zapparov <ixti@member.fsf.org> (http://www.ixti.net/)",
+    "Vitaly Puzrin <vitaly@rcdesign.ru> (https://github.com/puzrin)",
+    "Martin Grenfell <martin.grenfell@gmail.com> (http://got-ravings.blogspot.com)"
+  ],
+  "license": "MIT",
+  "repository": "nodeca/js-yaml",
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/puzrin"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/nodeca"
+    }
+  ],
+  "files": [
+    "bin/",
+    "dist/"
+  ],
+  "bin": {
+    "js-yaml": "bin/js-yaml.mjs"
+  },
+  "main": "./dist/js-yaml.cjs.js",
+  "module": "./dist/js-yaml.mjs",
+  "types": "./dist/js-yaml.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/js-yaml.d.ts",
+      "import": "./dist/js-yaml.mjs",
+      "require": "./dist/js-yaml.cjs.js"
+    },
+    "./browser": {
+      "types": "./dist/js-yaml.d.ts",
+      "import": "./dist/browser/js-yaml.esm.min.mjs",
+      "require": "./dist/browser/js-yaml.umd.min.js",
+      "default": "./dist/browser/js-yaml.umd.min.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "lint-fix": "eslint . --fix",
+    "type-check": "tsc --noEmit",
+    "test": "npm run lint && npm run build && npm run type-check && npm run test:examples && npm run spec:get && node --test 'test/core/**/*.test.mjs' 'test/spec/*.test.mjs'",
+    "test:examples": "node --test 'examples/*.mjs'",
+    "test:spec": "npm run build && npm run spec:get && node test/spec/spec.test.mjs",
+    "spec:get": "node support/get-yaml-test-suite.mjs",
+    "spec:update": "node support/get-yaml-test-suite.mjs update",
+    "coverage": "npm run build && npm run spec:get && c8 --include 'dist/js-yaml.mjs' --include 'src/**' -r text -r html -r lcov node --test 'test/core/**/*.test.mjs' 'test/spec/*.test.mjs'",
+    "build": "node support/build-dist.mjs",
+    "build:demo": "npm run lint && node support/build_demo.mjs",
+    "gh-demo": "npm run build:demo && gh-pages -d demo -f",
+    "benchmark:deps": "npm install --prefix benchmark/extra/",
+    "prepack": "npm test && npm run build && npm run build:demo",
+    "postpublish": "npm run gh-demo"
+  },
+  "dependencies": {
+    "argparse": "^2.0.1"
+  },
+  "devDependencies": {
+    "@streamparser/json": "^0.0.22",
+    "@types/node": "^24.12.2",
+    "c8": "^11.0.0",
+    "codemirror": "^5.65.21",
+    "eslint": "^9.39.4",
+    "fast-check": "^4.8.0",
+    "gh-pages": "^6.3.0",
+    "mitata": "^1.0.34",
+    "neostandard": "^0.13.0",
+    "rollup": "^4.62.2",
+    "rollup-plugin-dts": "^6.4.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.2",
+    "vite-plugin-node-polyfills": "^0.28.0",
+    "vite-plugin-singlefile": "^2.3.3",
+    "workerpool": "^10.0.3"
+  }
+}


### PR DESCRIPTION
## Problem

The Spec Kit Wizard canvas was failing to open on machines behind corporate TLS interception (Microsoft internal network, common enterprise setups) with:

```
npm error code ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE
npm error request to https://registry.npmjs.org/js-yaml failed
```

Root cause: on first open, the canvas ran `npm install js-yaml` and hard-threw `Spec Kit Wizard cannot start` when the install failed. Copilot CLI doesn't run `npm install` for canvas extensions, and internal networks with MITM TLS often block the npm registry, so the workaround was fragile.

## Fix (two layers)

### 1. Vendor a trimmed `js-yaml` + `argparse`
- Adds `plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/node_modules/{js-yaml,argparse}/` to git.
- Trimmed to only what Node's ESM resolver actually needs: dropped source maps, the browser build, and CLI bins. About 1.6 MB down to ~420 KB.
- `.gitignore` gets a scoped exception for that path; `.gitattributes` normalizes line endings.
- Plugin now installs self-contained. No npm ever needed.

### 2. Graceful degradation if the vendored copy is somehow missing
- If `checkDeps()` reports missing and `installDeps()` also fails, the canvas now logs a warning and **opens anyway** instead of throwing.
- Only Catalogs and Composition pages consume `js-yaml` (to parse `preset.yml` / `bundle.yml`). Setup, Environment, and Phases pages continue to work.

## Verification

- `node --test test/*.test.mjs` -> 214/214 pass.
- Confirmed js-yaml loads via `import('js-yaml')` and parses correctly with only the trimmed vendored files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>