### PR TITLE
docs(wizard): explain how to recover from first-open npm failures

### DIFF
--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/README.md
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/README.md
@@ -183,6 +183,49 @@ live where Spec Kit puts them: `.specify/memory/constitution.md` and
 `specs/<slug>/{spec,plan,tasks,analysis}.md` plus
 `specs/<slug>/checklists/`.
 
+## Troubleshooting
+
+**First open shows "Spec Kit Wizard cannot start" or an npm error like
+`ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE`, `ECONNREFUSED`, `ETIMEDOUT`,
+or `403 Forbidden` against `registry.npmjs.org`.**
+
+The first time the canvas opens in a fresh clone or worktree it runs
+`npm install js-yaml` in the extension folder. If your machine can't
+reach the public npm registry — typically due to a corporate proxy,
+egress firewall, or TLS-inspecting appliance — that install fails and
+the wizard refuses to start. This is an npm reachability problem on the
+host, not a wizard bug. `package-lock.json` doesn't help here: it only
+pins versions, npm still has to fetch packages from a registry.
+
+Pick whichever applies:
+
+1. **Configure npm to use a registry you *can* reach.** If your org
+   provides an approved npm mirror (Azure Artifacts, JFrog Artifactory,
+   Nexus, Verdaccio, GitHub Packages, etc.), point npm at it:
+   ```
+   npm config set registry https://<your-approved-mirror>/npm/registry/
+   ```
+   Verify with `npm install --dry-run js-yaml` in any empty folder, then
+   close and reopen the wizard canvas.
+2. **Trust your corporate root CA.** If your network intercepts TLS,
+   npm needs the corporate CA:
+   ```
+   npm config set cafile "/path/to/corp-root-ca.pem"
+   ```
+   Your IT/security team can point you at the cert.
+3. **Install the dep manually, once**, then reopen the canvas:
+   ```
+   cd <path-to>/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas
+   npm install js-yaml
+   ```
+   After this succeeds the wizard skips the auto-install on every
+   subsequent open in the same folder.
+
+If none of the above are available in your environment, `js-yaml` is
+only used by the **Catalogs** and **Composition** pages; the rest of
+the wizard doesn't need it. Manual install (option 3) is the smallest
+change and doesn't require any org-wide npm reconfiguration.
+
 ## Files
 
 | File | Purpose |


### PR DESCRIPTION
## Problem

Users behind corporate proxies or TLS-inspecting egress firewalls can hit `ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE` (or `ECONNREFUSED` / `ETIMEDOUT` / `403`) on the wizard's first-open `npm install js-yaml`. The result is a raw ""Spec Kit Wizard cannot start"" error with no clear next step — a 3rd party has no way to know it's an npm reachability problem on their host, not a wizard bug.

## Fix (docs-only)

Adds a Troubleshooting section to `plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/README.md` describing three vendor-neutral recovery paths:

1. Point npm at an approved mirror (whichever your org actually uses).
2. Install the corporate root CA so npm trusts the intercepted TLS.
3. Run `npm install js-yaml` manually, once, in the extension folder.

Also notes:

- `package-lock.json` does **not** solve this — it only pins versions, npm still has to reach a registry.
- `js-yaml` is only used by the **Catalogs** and **Composition** pages, so option 3 (manual install) is the smallest and most portable recovery.

No code changes. No new dependencies. No preference for any specific vendor registry.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>