### PR TITLE
Spec Kit Wizard: live boot progress + agent-assisted npm troubleshooting

### DIFF
--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/README.md
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/README.md
@@ -124,6 +124,12 @@ accordingly. The extension registers **11 actions** across four groups:
   the Install button).
 - `reloadSessionSkills` — reload Copilot's in-memory skill registry for
   the session (equivalent to `/skills reload`).
+- `runNpmDiagnostics` — dispatch a scripted npm-diagnostic prompt to the
+  parent session so the Copilot agent walks a checklist (inspect
+  `~/.npmrc`, ask about the org's approved feed / CA / proxy, propose a
+  minimal config change, retry the install, call `refreshEnvironment`
+  when done). Wired to the "Diagnose and fix with the agent" button on
+  the boot overlay's deps-error card. See [First-open boot](#first-open-boot).
 
 **UI navigation (push state to a tab):**
 - `showPresetCatalog` — push the preset catalog to the Catalogs tab.
@@ -176,6 +182,38 @@ flow recognize it.
   (`js-yaml`) is used for reading preset / bundle YAML.
   The wizard installs it automatically on first open of a fresh clone
   or worktree — no manual `npm install` needed.
+
+<a id="first-open-boot"></a>
+
+### First-open boot
+
+On first open of a fresh worktree, the wizard shows a live boot overlay
+while the backend runs its startup checklist: **workspace → deps-check
+→ deps-install → env-probe → catalog → ready**. The HTTP server is
+started *first*, before any long-running work, so the canvas iframe
+loads within ~1 second and each step animates in place with an elapsed
+timer. The `deps-install` row streams npm's live output as the last
+line under the row title, so users see progress instead of a blank
+"installing…" spinner.
+
+If `npm install` fails (e.g. a corporate TLS-inspecting proxy blocks
+`registry.npmjs.org`), the deps-install row is replaced in-place with
+an error card classifying the failure and offering two buttons:
+
+- **Diagnose and fix with the agent** — dispatches a scripted prompt
+  to the Copilot agent (via the `runNpmDiagnostics` canvas action).
+  The agent inspects `~/.npmrc`, asks about the user's approved
+  internal feed / CA / proxy, proposes a minimal config change, and
+  retries the install. When it succeeds the agent calls
+  `refreshEnvironment`; the boot overlay picks up the new state and
+  animates through the remaining steps.
+- **Retry install** — re-runs `installDeps` on the same backend, so
+  the same overlay progress + error classification pipeline covers the
+  retry too.
+
+The wizard never hard-fails on install failure — the canvas stays
+open with the actionable boot overlay so users can self-serve the
+repair without closing the panel.
 
 The wizard writes its own control-plane state to
 `.speckit-wizard/state.json` in the target project. Artifact files

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/actions/deps-recovery.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/actions/deps-recovery.mjs
@@ -1,0 +1,57 @@
+// Canvas actions for deps-error recovery.
+//
+// runNpmDiagnostics — dispatch a scripted prompt to the parent session so
+// the Copilot agent walks the diagnostic + repair checklist and calls the
+// existing `refreshEnvironment` action when done. Fire-and-forget — the
+// action returns immediately; the agent's turn shows up in chat.
+//
+// Mirrors the shape of catalog.mjs actions and reuses the shared
+// dispatchPromptToSession helper (same fire-and-forget send used
+// everywhere else in the wizard).
+
+import { withInstance } from "../instances.mjs";
+import { dispatchPromptToSession } from "../dispatch.mjs";
+import { buildNpmDiagnosticPrompt } from "../../env/deps-recovery.mjs";
+import { getExtensionDir } from "../../env/deps-check.mjs";
+
+export const depsRecoveryActions = [
+    {
+        name: "runNpmDiagnostics",
+        description:
+            "Ask the Copilot agent to diagnose and repair a failed `npm install` for the wizard canvas's js-yaml dependency. The agent will inspect `~/.npmrc`, ask about the user's org's approved feed / CA / proxy, propose a minimal config change, retry the install, and call `refreshEnvironment` when the install succeeds. Use this when the boot overlay shows a `deps-install` failure.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                errorCode: {
+                    type: "string",
+                    description:
+                        "Optional classified npm error code. When omitted, the most recent classified error stashed on the instance is used.",
+                },
+                force: {
+                    type: "boolean",
+                    description:
+                        "When true, dispatch even if there is no cached error (useful when the user opens the canvas and clicks the button before the failure is broadcast).",
+                },
+            },
+        },
+        handler: (ctx) =>
+            withInstance(ctx, (inst) => {
+                const cached = inst?.depsError ?? null;
+                const errorCode = typeof ctx.input?.errorCode === "string" && ctx.input.errorCode.trim()
+                    ? ctx.input.errorCode.trim()
+                    : cached?.code ?? "UNKNOWN";
+                const force = !!ctx.input?.force;
+                if (!cached && !force) {
+                    return { ok: false, error: "no cached deps error; pass force: true to dispatch anyway" };
+                }
+                const prompt = buildNpmDiagnosticPrompt({
+                    extDir: cached?.extDir ?? getExtensionDir(),
+                    errorCode,
+                    stderr: cached?.stderrTail ?? "",
+                    workspacePath: inst?.workspacePath ?? null,
+                });
+                dispatchPromptToSession({ prompt });
+                return { ok: true, errorCode };
+            }),
+    },
+];

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/boot-progress.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/boot-progress.mjs
@@ -1,0 +1,185 @@
+// Boot-progress tracker for the wizard canvas.
+//
+// Why this exists
+// ---------------
+// First open of a fresh worktree is slow: workspace probe, npm install
+// (10-45s on cold cache), env probe, catalog hydrate. The canvas SDK
+// blocks the iframe on the URL returned from `onOpen`, so users
+// historically saw a blank frame for the entire boot. This tracker
+// gives the UI a live, streamable picture of what step we're on,
+// how long it's been running, and what (if anything) failed.
+//
+// Contract
+// --------
+// createBootTracker({ broadcast, inst }) returns an object with:
+//   start(stepId)              — mark step as running (records startedAt)
+//   ok(stepId, meta?)          — mark step as ok  (records endedAt/durationMs)
+//   fail(stepId, err)          — mark step as failed (records error + endedAt)
+//   skip(stepId, reason?)      — mark step as skipped (records endedAt)
+//   tick(stepId, line)         — attach a rolling "last output line" for
+//                                the running step (throttled broadcast)
+//   ready()                    — mark tracker as phase=ready
+//   snapshot()                 — return a serializable clone
+//
+// Every mutation writes back to inst.boot AND fires a broadcast(
+// { type: "boot.update", boot }) so subscribers (SSE clients) see it
+// immediately. tick() is throttled to ~5Hz to avoid flooding the SSE
+// stream with npm log spam.
+
+// Ordered list of steps the wizard walks on first open. Changing this
+// list requires updating ui/boot.js.
+export const BOOT_STEPS = [
+    { id: "workspace", label: "Resolving workspace" },
+    { id: "deps-check", label: "Checking npm dependencies" },
+    { id: "deps-install", label: "Installing js-yaml" },
+    { id: "env-probe", label: "Probing environment" },
+    { id: "catalog", label: "Loading catalogs" },
+    { id: "ready", label: "Ready" },
+];
+
+const TICK_THROTTLE_MS = 200;
+
+function nowIso() {
+    return new Date().toISOString();
+}
+
+function initialBoot() {
+    const startedAt = nowIso();
+    return {
+        phase: "booting",
+        startedAt,
+        steps: BOOT_STEPS.map((s) => ({
+            id: s.id,
+            label: s.label,
+            status: "pending",
+            startedAt: null,
+            endedAt: null,
+            durationMs: null,
+            output: null,
+            error: null,
+            meta: null,
+        })),
+    };
+}
+
+export function createBootTracker({ broadcast, inst } = {}) {
+    if (!inst) throw new Error("createBootTracker requires inst");
+    // Preserve an existing boot record if we're re-running after a
+    // retry — the UI still animates the retried step.
+    if (!inst.boot || !Array.isArray(inst.boot.steps)) {
+        inst.boot = initialBoot();
+    }
+
+    const lastTickAt = new Map();
+    const pendingTickTimer = new Map();
+
+    function step(stepId) {
+        const s = inst.boot.steps.find((x) => x.id === stepId);
+        if (!s) throw new Error(`unknown boot step: ${stepId}`);
+        return s;
+    }
+
+    function emit() {
+        try {
+            broadcast?.({ type: "boot.update", boot: snapshot() });
+        } catch { /* best-effort */ }
+    }
+
+    function start(stepId) {
+        const s = step(stepId);
+        s.status = "running";
+        s.startedAt = nowIso();
+        s.endedAt = null;
+        s.durationMs = null;
+        s.error = null;
+        s.output = null;
+        emit();
+    }
+
+    function finalize(s, status) {
+        s.status = status;
+        s.endedAt = nowIso();
+        if (s.startedAt) {
+            s.durationMs = Math.max(0, Date.parse(s.endedAt) - Date.parse(s.startedAt));
+        }
+        // Cancel any pending throttled tick emission for this step so a
+        // late line doesn't overwrite the finalized status.
+        const pending = pendingTickTimer.get(s.id);
+        if (pending) {
+            clearTimeout(pending);
+            pendingTickTimer.delete(s.id);
+        }
+        lastTickAt.delete(s.id);
+    }
+
+    function ok(stepId, meta = null) {
+        const s = step(stepId);
+        finalize(s, "ok");
+        if (meta) s.meta = meta;
+        emit();
+    }
+
+    function fail(stepId, err = null) {
+        const s = step(stepId);
+        finalize(s, "failed");
+        if (err) {
+            s.error = typeof err === "string"
+                ? { title: err }
+                : {
+                    title: err.title ?? err.message ?? "failed",
+                    hint: err.hint ?? null,
+                    code: err.code ?? null,
+                    canRetry: err.canRetry ?? true,
+                    stderrTail: typeof err.stderrTail === "string" ? err.stderrTail.slice(0, 400) : null,
+                };
+        }
+        inst.boot.phase = "failed";
+        emit();
+    }
+
+    function skip(stepId, reason = null) {
+        const s = step(stepId);
+        s.startedAt = s.startedAt ?? nowIso();
+        finalize(s, "skipped");
+        if (reason) s.meta = { reason };
+        emit();
+    }
+
+    function tick(stepId, line) {
+        const s = step(stepId);
+        if (s.status !== "running") return;
+        const trimmed = typeof line === "string" ? line.trim() : "";
+        if (!trimmed) return;
+        s.output = trimmed.slice(0, 200);
+        const now = Date.now();
+        const last = lastTickAt.get(stepId) ?? 0;
+        const wait = TICK_THROTTLE_MS - (now - last);
+        if (wait <= 0) {
+            lastTickAt.set(stepId, now);
+            emit();
+        } else if (!pendingTickTimer.get(stepId)) {
+            const timer = setTimeout(() => {
+                pendingTickTimer.delete(stepId);
+                lastTickAt.set(stepId, Date.now());
+                emit();
+            }, wait);
+            // Don't hold the process open on this timer.
+            if (typeof timer.unref === "function") timer.unref();
+            pendingTickTimer.set(stepId, timer);
+        }
+    }
+
+    function ready() {
+        const s = step("ready");
+        finalize(s, "ok");
+        inst.boot.phase = "ready";
+        emit();
+    }
+
+    function snapshot() {
+        // Deep clone via JSON so subscribers can't mutate the live record.
+        return JSON.parse(JSON.stringify(inst.boot));
+    }
+
+    return { start, ok, fail, skip, tick, ready, snapshot };
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/snapshot-builder.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/snapshot-builder.mjs
@@ -31,6 +31,8 @@ export function buildStateSnapshot(scan) {
             composition: { presets: [], extensions: [] },
             catalog: { presets: [{ id: "core", name: "core", source: "builtin", active: true }] },
             environment: null,
+            boot: null,
+            depsError: null,
             warnings: [],
         };
     }
@@ -142,6 +144,8 @@ export function buildStateSnapshot(scan) {
         composition: scan.composition ?? { presets: [], extensions: [] },
         catalog: scan.catalog ?? { presets: [] },
         environment: scan.environment ?? null,
+        boot: scan.boot ?? null,
+        depsError: scan.depsError ?? null,
         scaffoldedSkills: Array.isArray(scan.scaffoldedSkills) ? scan.scaffoldedSkills : [],
         warnings: Array.isArray(scan.warnings) ? scan.warnings.slice(0, 20) : [],
     };

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/snapshot.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/canvas-runtime/snapshot.mjs
@@ -75,6 +75,10 @@ export async function snapshot(inst) {
     if (inst.cachedProbes?.summary) {
         scan.environment = inst.cachedProbes.summary;
     }
+    // Overlay boot progress + deps error so the UI's initial fetch
+    // reflects live state without waiting for the next SSE event.
+    if (inst.boot) scan.boot = inst.boot;
+    if (inst.depsError) scan.depsError = inst.depsError;
     // Setup step "done" state is derived live from `scan.environment` (plugin
     // and CLI probes) and `scan.projectInitialized` (fs check on .specify/),
     // NOT from persisted setup.* flags — those drift when things are

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/env/deps-check.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/env/deps-check.mjs
@@ -55,6 +55,8 @@ import { stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { classifyNpmError } from "./deps-error-classifier.mjs";
+
 const EXT_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
 
 // A single package.json under node_modules is a cheap-and-reliable
@@ -87,20 +89,31 @@ export async function checkDeps() {
 
 /**
  * Run `npm install <packages>` inside the extension directory to install any
- * missing runtime deps. Resolves with { ok, stdout, stderr, code }. Never
- * throws — callers inspect `ok` and surface a friendly message if false.
+ * missing runtime deps. Resolves with { ok, stdout, stderr, code, classified? }.
+ * Never throws — callers inspect `ok` and surface a friendly message if false.
+ *
+ * `onProgress(line)` is invoked with each stdout/stderr line as it arrives
+ * so the boot UI can show a live "npm is doing something" status. The
+ * caller is expected to throttle broadcasts of these lines.
  *
  * @param {string[]} packages
- * @returns {Promise<{ ok: boolean, stdout: string, stderr: string, code: number | null }>}
+ * @param {{ onProgress?: (line: string) => void }} [opts]
+ * @returns {Promise<{ ok: boolean, stdout: string, stderr: string, code: number | null, classified?: object }>}
  */
-export function installDeps(packages) {
+export function installDeps(packages, opts = {}) {
+    const onProgress = typeof opts.onProgress === "function" ? opts.onProgress : null;
     return new Promise((resolve) => {
         if (!packages || packages.length === 0) {
             resolve({ ok: true, stdout: "", stderr: "", code: 0 });
             return;
         }
         const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        const args = ["install", "--no-audit", "--no-fund", "--silent", ...packages];
+        // Drop --silent when streaming progress so the UI sees fetch/reify
+        // lines. --loglevel=info gives useful progress without dumping the
+        // full trace.
+        const args = onProgress
+            ? ["install", "--no-audit", "--no-fund", "--loglevel=info", ...packages]
+            : ["install", "--no-audit", "--no-fund", "--silent", ...packages];
         let child;
         try {
             child = spawn(npmCmd, args, {
@@ -116,18 +129,50 @@ export function installDeps(packages) {
                 stdio: ["ignore", "pipe", "pipe"],
             });
         } catch (err) {
-            resolve({ ok: false, stdout: "", stderr: String(err?.message || err), code: null });
+            const missingBinary = err?.code === "ENOENT";
+            const stderr = String(err?.message || err);
+            resolve({
+                ok: false,
+                stdout: "",
+                stderr,
+                code: null,
+                classified: classifyNpmError({ stderr, missingBinary }),
+            });
             return;
         }
         let stdout = "";
         let stderr = "";
-        child.stdout?.on("data", (d) => { stdout += d.toString(); });
-        child.stderr?.on("data", (d) => { stderr += d.toString(); });
+        // Line-buffer so onProgress sees meaningful units. npm prints
+        // progress bar frames a lot; we keep the last non-blank line.
+        const feed = (buf, sinkKey) => {
+            const s = buf.toString();
+            if (sinkKey === "stdout") stdout += s; else stderr += s;
+            if (!onProgress) return;
+            for (const raw of s.split(/\r?\n/)) {
+                const line = raw.trim();
+                if (line) {
+                    try { onProgress(line); } catch { /* best-effort */ }
+                }
+            }
+        };
+        child.stdout?.on("data", (d) => feed(d, "stdout"));
+        child.stderr?.on("data", (d) => feed(d, "stderr"));
         child.on("error", (err) => {
-            resolve({ ok: false, stdout, stderr: stderr + String(err?.message || err), code: null });
+            const missingBinary = err?.code === "ENOENT";
+            const merged = stderr + String(err?.message || err);
+            resolve({
+                ok: false,
+                stdout,
+                stderr: merged,
+                code: null,
+                classified: classifyNpmError({ stderr: merged, stdout, missingBinary }),
+            });
         });
         child.on("close", (code) => {
-            resolve({ ok: code === 0, stdout, stderr, code });
+            const ok = code === 0;
+            const result = { ok, stdout, stderr, code };
+            if (!ok) result.classified = classifyNpmError({ stderr, stdout, code });
+            resolve(result);
         });
     });
 }

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/env/deps-error-classifier.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/env/deps-error-classifier.mjs
@@ -1,0 +1,103 @@
+// Classify an npm install failure into a small, actionable set of codes.
+//
+// The wizard canvas runs `npm install js-yaml` on first open. When that
+// fails, the raw stderr is unhelpful to end-users (schannel error codes,
+// EPROXY, SELF_SIGNED_CERT_IN_CHAIN, etc). This module reduces the noise
+// to a fixed set of codes + a plain-English title/hint so the UI can:
+//
+//   1. render an actionable error card, and
+//   2. hand the code off to the agent-diagnostic prompt so the agent
+//      knows what to attempt first.
+//
+// The classifier is deliberately narrow, string-matches on real stderr
+// fragments captured in the wild, and prefers the most specific match.
+// Unknown failures fall through to UNKNOWN — the UI still shows a card,
+// just with a generic title/hint.
+
+/**
+ * @typedef {"TLS_HANDSHAKE" | "CERT_UNTRUSTED" | "CONN_REFUSED"
+ *   | "DNS_UNRESOLVED" | "HTTP_403" | "HTTP_407_PROXY"
+ *   | "NPM_MISSING" | "UNKNOWN"} NpmErrorCode
+ */
+
+/**
+ * @param {{ stderr?: string, stdout?: string, code?: number|null, missingBinary?: boolean }} input
+ * @returns {{ code: NpmErrorCode, title: string, hint: string, canRetry: boolean }}
+ */
+export function classifyNpmError(input = {}) {
+    const stderr = String(input.stderr ?? "");
+    const stdout = String(input.stdout ?? "");
+    const text = `${stderr}\n${stdout}`;
+    const missingBinary = !!input.missingBinary;
+
+    if (missingBinary) {
+        return {
+            code: "NPM_MISSING",
+            title: "npm is not on PATH",
+            hint: "Install Node.js (which includes npm) and reopen the canvas.",
+            canRetry: false,
+        };
+    }
+
+    // Order matters: check specific/high-signal fragments before generic ones.
+    if (/HANDSHAKE_FAILURE|SEC_E_ILLEGAL_MESSAGE|schannel: SEC_E|alert handshake failure|EPROTO/.test(text)) {
+        return {
+            code: "TLS_HANDSHAKE",
+            title: "npm can't complete a TLS handshake with the registry",
+            hint: "A corporate TLS-inspecting proxy or firewall is likely blocking registry.npmjs.org. Configure npm to use your organization's approved mirror.",
+            canRetry: true,
+        };
+    }
+
+    if (/SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_GET_ISSUER_CERT_LOCALLY|unable to verify the first certificate|CERT_UNTRUSTED/i.test(text)) {
+        return {
+            code: "CERT_UNTRUSTED",
+            title: "npm can't verify the registry's TLS certificate",
+            hint: "A corporate certificate is intercepting HTTPS. Point npm at your organization's CA bundle (`npm config set cafile`).",
+            canRetry: true,
+        };
+    }
+
+    if (/HTTP\s?407|407 Proxy Authentication Required|Proxy Authentication Required/i.test(text)) {
+        return {
+            code: "HTTP_407_PROXY",
+            title: "npm needs to authenticate with a proxy",
+            hint: "Set `HTTPS_PROXY` (or npm's `https-proxy` config) with credentials your proxy accepts.",
+            canRetry: true,
+        };
+    }
+
+    if (/HTTP\s?403|E403|Forbidden|Registry returned 403/i.test(text)) {
+        return {
+            code: "HTTP_403",
+            title: "The npm registry rejected the request (HTTP 403)",
+            hint: "Check that your account/token has permission for js-yaml, or switch to your organization's approved feed.",
+            canRetry: true,
+        };
+    }
+
+    if (/ECONNREFUSED|connect ECONNREFUSED/i.test(text)) {
+        return {
+            code: "CONN_REFUSED",
+            title: "npm couldn't connect to the registry",
+            hint: "The registry host refused the TCP connection. Check that you're online and that no local proxy is blocking outbound HTTPS.",
+            canRetry: true,
+        };
+    }
+
+    if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(text)) {
+        return {
+            code: "DNS_UNRESOLVED",
+            title: "npm couldn't resolve the registry hostname",
+            hint: "DNS lookup failed for the npm registry. Confirm you're online, and check your DNS or VPN configuration.",
+            canRetry: true,
+        };
+    }
+
+    return {
+        code: "UNKNOWN",
+        title: "npm install failed",
+        hint: "The Copilot agent can walk you through diagnosing the cause and repairing your npm configuration.",
+        canRetry: true,
+    };
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/env/deps-recovery.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/env/deps-recovery.mjs
@@ -1,0 +1,87 @@
+// Build the agent prompt used by the "Diagnose and fix with the agent"
+// button on the wizard canvas.
+//
+// The prompt is a self-contained, numbered checklist the Copilot agent
+// walks in the parent chat session. It carries the extension folder path
+// so the agent doesn't have to guess where to install, the classified
+// error code so it knows what to attempt first, and a short stderr tail
+// as evidence. When the fix succeeds it must call the wizard's
+// `refreshEnvironment` canvas action so the diagnostic card clears.
+
+const CODE_HINTS = {
+    TLS_HANDSHAKE:
+        "Focus on TLS: a corporate TLS-inspecting proxy is almost certainly rewriting the handshake. Check whether the user's org has an approved npm mirror and whether npm needs to trust a corporate CA bundle.",
+    CERT_UNTRUSTED:
+        "Focus on certificates: an intercepting proxy is presenting a certificate npm doesn't trust. The user's org likely publishes a CA bundle — configure npm to use it via `npm config set cafile`.",
+    HTTP_407_PROXY:
+        "Focus on proxy authentication: the user is behind an authenticated corporate proxy. Configure `HTTPS_PROXY` / `HTTP_PROXY` and npm's `https-proxy` / `http-proxy` with credentials the proxy accepts.",
+    HTTP_403:
+        "Focus on registry authorization: either the user's account lacks permission or the wrong registry is configured. Check whether the org uses a private feed and switch npm to it if so.",
+    CONN_REFUSED:
+        "Focus on connectivity: something is refusing the TCP connection to the registry. Confirm the user is online and no local proxy is intercepting HTTPS.",
+    DNS_UNRESOLVED:
+        "Focus on DNS: the registry hostname isn't resolving. Confirm the user is online (VPN state?) and check DNS configuration.",
+    NPM_MISSING:
+        "npm is not installed or not on PATH. Ask the user to install Node.js (which includes npm) from https://nodejs.org, then reopen the canvas.",
+    UNKNOWN:
+        "The failure did not match a known pattern. Walk the diagnostic checklist below and report back what you find before attempting any fix.",
+};
+
+function truncateStderr(s) {
+    const raw = String(s ?? "").trim();
+    if (!raw) return "(no stderr captured)";
+    // Zero-width space between backticks so a stderr line containing "```"
+    // can't break out of the markdown code fence in the dispatched prompt
+    // (a compromised registry/proxy could otherwise inject instructions).
+    const safe = raw.replace(/`{3,}/g, (m) => m.split("").join("\u200B"));
+    if (safe.length <= 1200) return safe;
+    return safe.slice(0, 1200) + "\n… (truncated)";
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.extDir         Absolute path to the extension folder.
+ * @param {string} opts.errorCode      Classified npm error code (see classifier).
+ * @param {string} [opts.stderr]       Raw stderr from the failed install.
+ * @param {string} [opts.workspacePath] User workspace path (for context).
+ * @returns {string}
+ */
+export function buildNpmDiagnosticPrompt({ extDir, errorCode, stderr = "", workspacePath = null } = {}) {
+    if (!extDir || typeof extDir !== "string") {
+        throw new Error("buildNpmDiagnosticPrompt requires extDir");
+    }
+    const codeHint = CODE_HINTS[errorCode] ?? CODE_HINTS.UNKNOWN;
+    const wsLine = workspacePath ? `\nUser workspace: ${workspacePath}` : "";
+    return [
+        "The Spec Kit Wizard canvas failed to install its js-yaml dependency and is asking you to diagnose the underlying npm/network problem.",
+        "",
+        `Classified error code: **${errorCode}**`,
+        `Extension folder (run every npm command inside this folder): ${extDir}${wsLine}`,
+        "",
+        `Guidance for this error code: ${codeHint}`,
+        "",
+        "Captured stderr:",
+        "```",
+        truncateStderr(stderr),
+        "```",
+        "",
+        "Walk this checklist step by step. Report what you find between steps so the user can follow along. Do NOT make edits without explaining what you're changing and why.",
+        "",
+        "1. Read the user's current npm config: `npm config list -l` (and `npm config get registry`, `cafile`, `https-proxy`).",
+        "2. Read `~/.npmrc` if present (create the file if it doesn't exist and edits are needed). Do not touch project-level `.npmrc` unless the user asks.",
+        "3. Ask the user which of the following applies (offer as a short numbered choice):",
+        "   a. They have an approved corporate npm mirror URL (paste it).",
+        "   b. Their org publishes a corporate CA bundle (path to .pem/.crt).",
+        "   c. They're behind an authenticated proxy (share HTTPS_PROXY value).",
+        "   d. None of the above / they don't know — recommend they check with IT.",
+        "4. Based on the answer, propose the minimal `~/.npmrc` change (registry=, cafile=, https-proxy=, or a strict-ssl override as a last resort). Show the exact diff before applying.",
+        "5. Apply the change with the user's confirmation.",
+        `6. Retry the install with: \`cd "${extDir}" && npm install --no-audit --no-fund\``,
+        "7. If it succeeds, invoke the wizard's `refreshEnvironment` canvas action (canvasId `speckit-wizard`) so the diagnostic banner clears. If it fails again, capture the new stderr, re-classify, and continue the loop.",
+        "",
+        "Constraints:",
+        "- Never disable TLS certificate validation project-wide without the user's explicit consent.",
+        "- Never commit secrets (proxy credentials, tokens) to any file that could be checked in.",
+        "- Prefer the least-invasive fix — a user-level `~/.npmrc` change over a system-wide one.",
+    ].join("\n");
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/extension.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/extension.mjs
@@ -19,6 +19,7 @@ import { joinSession, createCanvas } from "@github/copilot-sdk/extension";
 import { readState } from "./state/store.mjs";
 import { startServer } from "./server.mjs";
 import { checkDeps, getExtensionDir, installDeps } from "./env/deps-check.mjs";
+import { createBootTracker } from "./canvas-runtime/boot-progress.mjs";
 // Composition retrieval is entirely LLM-driven via the `speckit-preset` +
 // `speckit-extension` skills — see the `composition.refresh` case in
 // prompts.mjs and the `applyComposition` helper in canvas-runtime/composition-apply.mjs.
@@ -39,8 +40,9 @@ import { phaseActions } from "./canvas-runtime/actions/phase.mjs";
 import { catalogActions } from "./canvas-runtime/actions/catalog.mjs";
 import { compositionActions } from "./canvas-runtime/actions/composition.mjs";
 import { wizardShellActions } from "./canvas-runtime/actions/wizard-shell.mjs";
+import { depsRecoveryActions } from "./canvas-runtime/actions/deps-recovery.mjs";
 
-const ACTIONS = [...phaseActions, ...catalogActions, ...compositionActions, ...wizardShellActions];
+const ACTIONS = [...phaseActions, ...catalogActions, ...compositionActions, ...wizardShellActions, ...depsRecoveryActions];
 
 // --------------------------- per-instance registry --------------------------
 // (record shape + `instances` Map now live in instances.mjs)
@@ -74,29 +76,11 @@ async function onOpen(ctx) {
     }
     inst.workspacePath = resolveWorkspace(inst, ctx, sessionState.repoPath);
 
-    // First-boot / new-worktree bootstrap: the wizard canvas has a small npm
-    // dependency (js-yaml) that isn't checked in. If it's missing, run
-    // `npm install` in the canvas folder automatically before starting
-    // the server. This adds a one-time ~10-30s delay on first open of a
-    // fresh worktree but avoids surfacing a raw error that the user then
-    // has to resolve manually.
-    let deps = await checkDeps();
-    if (!deps.ready) {
-        const installResult = await installDeps(deps.missing);
-        deps = await checkDeps();
-        if (!deps.ready) {
-            const extDir = getExtensionDir();
-            const pkgs = deps.missing.join(" ");
-            const detail = installResult.stderr?.trim() || installResult.stdout?.trim() || "npm install failed";
-            throw new Error(
-                `Spec Kit Wizard cannot start: automatic install of npm dependencies (${pkgs}) failed. ` +
-                `Run: npm install ${pkgs}  (in ${extDir}), then reopen the canvas.\n\n${detail}`,
-            );
-        }
-    }
-
-    await hydrateOnce(inst);
-
+    // Start the HTTP server FIRST so we can return the URL immediately.
+    // The iframe loads the boot overlay (ui/boot.js) which subscribes to
+    // SSE and animates step-by-step progress while npm install and
+    // hydration run in the background. This is what turns the historical
+    // 10-45s "blank iframe" first-open into a live experience.
     if (!inst.server) {
         const adapter = sessionAdapter();
         await startServer(inst.instanceId, {
@@ -106,6 +90,14 @@ async function onOpen(ctx) {
             getInstance: () => inst,
         });
     }
+
+    // Kick off boot work asynchronously — the promise is retained on the
+    // instance so a UI-initiated retry can await/replace it, but we do
+    // NOT await it here so the URL can return within ~1s.
+    inst.bootPromise = bootAsync(inst).catch((err) => {
+        try { sessionAdapter().log?.(`boot failed: ${err?.message ?? err}`, "error"); } catch {}
+    });
+
     // Start watching .speckit-wizard/state.json so external edits push
     // fresh state to the UI immediately.
     startStateWatcher(inst, { snapshot, normalizeHookArtifactsInComposition }).catch(() => { /* best-effort */ });
@@ -116,40 +108,131 @@ async function onOpen(ctx) {
     };
 }
 
-// First-boot hydration: state.json → env probe → catalog bootstrap →
-// initial snapshot. Extracted so onOpen stays a thin orchestrator.
-async function hydrateOnce(inst) {
-    // Load initial state.json (if present) and merge with a fresh scan.
+// Full boot sequence, broadcast step-by-step via the boot tracker so the
+// UI overlay can animate progress. Called fire-and-forget from onOpen
+// (with the promise retained on inst.bootPromise for retries).
+export async function bootAsync(inst) {
+    const adapter = sessionAdapter();
+    const tracker = createBootTracker({ broadcast: inst.broadcast, inst });
+
+    // Step 1: workspace resolution — this actually happened in onOpen
+    // before startServer, so just record it as ok/failed.
+    tracker.start("workspace");
     if (inst.workspacePath) {
-        const r = await readState(inst.workspacePath, fsDeps).catch(() => null);
-        if (r?.state) {
-            inst.state = r.state;
-            // Hydrate the in-memory composition cache from disk so the
-            // Composition tab renders instantly after an extension reload
-            // without re-running ~20 CLI calls.
-            if (r.state.composition) {
-                inst.cachedComposition = normalizeHookArtifactsInComposition(r.state.composition);
-            }
-            // `setup.skillsReloaded` is a durable, one-way-sticky milestone:
-            // once the project has ever completed a skills reload we keep the
-            // persisted flag `true` across process restarts, so the wizard
-            // doesn't relock the Phases tab every new Copilot session. If a
-            // consumer needs to know whether *this* process has reloaded, it
-            // should read `inst.skillsReload` (in-memory) — not the persisted
-            // flag. Do not reset the persisted value here.
+        tracker.ok("workspace", { path: inst.workspacePath });
+    } else {
+        tracker.fail("workspace", {
+            title: "Could not resolve a workspace path",
+            hint: "The canvas will still open, but phase pages need a workspace to save artifacts.",
+            canRetry: false,
+        });
+    }
+
+    // Step 2: deps-check
+    tracker.start("deps-check");
+    let deps;
+    try {
+        deps = await checkDeps();
+    } catch (err) {
+        tracker.fail("deps-check", { title: `checkDeps error: ${err?.message ?? err}` });
+        return;
+    }
+    if (deps.ready) {
+        tracker.ok("deps-check", { alreadyInstalled: true });
+        tracker.skip("deps-install", "already-installed");
+    } else {
+        tracker.ok("deps-check", { missing: deps.missing });
+
+        // Step 3: deps-install with live progress ticks.
+        tracker.start("deps-install");
+        const installResult = await installDeps(deps.missing, {
+            onProgress: (line) => tracker.tick("deps-install", line),
+        });
+        const recheck = await checkDeps();
+        if (recheck.ready) {
+            tracker.ok("deps-install", { installed: deps.missing });
+            inst.depsError = null;
+        } else {
+            const classified = installResult.classified ?? {
+                code: "UNKNOWN",
+                title: "npm install failed",
+                hint: "The Copilot agent can help diagnose the failure.",
+                canRetry: true,
+            };
+            const stderrTail = String(installResult.stderr ?? "").split(/\r?\n/).filter(Boolean).slice(-8).join("\n");
+            inst.depsError = {
+                ...classified,
+                extDir: getExtensionDir(),
+                packages: deps.missing,
+                stderrTail,
+                timestamp: new Date().toISOString(),
+            };
+            try {
+                adapter.log?.(
+                    `npm install failed [${classified.code}]: ${classified.title}. See wizard boot overlay for retry.`,
+                    "warn",
+                );
+            } catch { /* best-effort */ }
+            tracker.fail("deps-install", { ...classified, stderrTail });
+            // Don't return — the canvas still opens; catalog/composition
+            // pages that need js-yaml will surface their own error state.
         }
     }
-    // Kick off an env probe in the background — non-blocking.
-    // When it finishes, push a fresh snapshot so the Setup page shows the
-    // detected CLI / plugin versions without requiring a page refresh.
-    ensureEnvProbe(inst)
-        .then(async () => {
-            try {
-                const snap = await snapshot(inst);
-                inst.broadcast({ type: "state", data: snap });
-            } catch { /* best-effort */ }
-        })
-        .catch(() => {});
+
+    // Step 4: env-probe — split out of the old hydrateOnce so users see it.
+    tracker.start("env-probe");
+    try {
+        await hydrateReadState(inst);
+        // Fire the env probe and await it here (unlike the old code) so the
+        // step transitions ok when versions land.
+        await ensureEnvProbe(inst);
+        tracker.ok("env-probe");
+        try {
+            const snap = await snapshot(inst);
+            inst.broadcast?.({ type: "state", data: snap });
+        } catch { /* best-effort */ }
+    } catch (err) {
+        tracker.fail("env-probe", { title: `env probe failed: ${err?.message ?? err}` });
+    }
+
+    // Step 5: catalog bootstrap + fast composition.
+    tracker.start("catalog");
+    try {
+        await hydrateCatalogs(inst);
+        await runFastComposition(inst, { reason: "boot" });
+        await snapshot(inst);
+        tracker.ok("catalog");
+    } catch (err) {
+        tracker.fail("catalog", { title: `catalog hydrate failed: ${err?.message ?? err}` });
+    }
+
+    // Step 6: ready
+    tracker.ready();
+    try {
+        const snap = await snapshot(inst);
+        inst.broadcast?.({ type: "state", data: snap });
+    } catch { /* best-effort */ }
+}
+
+// Load state.json into inst.state (was the top of the old hydrateOnce).
+async function hydrateReadState(inst) {
+    if (!inst.workspacePath) return;
+    const r = await readState(inst.workspacePath, fsDeps).catch(() => null);
+    if (r?.state) {
+        inst.state = r.state;
+        // Hydrate the in-memory composition cache from disk so the
+        // Composition tab renders instantly after an extension reload
+        // without re-running ~20 CLI calls.
+        if (r.state.composition) {
+            inst.cachedComposition = normalizeHookArtifactsInComposition(r.state.composition);
+        }
+    }
+}
+
+// Catalog bootstrap: presets → extensions → bundles. Same content as the
+// old hydrateOnce, just factored out so bootAsync can time it as its own
+// step and the retry endpoint can re-run just this phase.
+async function hydrateCatalogs(inst) {
     // On a fresh instance (extension reload etc.) we auto-hydrate from the
     // hardcoded plugin catalog URLs so the Catalogs tab is populated without
     // requiring the user to re-run the skill.
@@ -188,8 +271,6 @@ async function hydrateOnce(inst) {
         inst.cachedCatalogSources = bootstrap;
         await hydratePresetsForSources(inst, bootstrap).catch(() => {});
     }
-    // Extension catalog bootstrap — same pattern as presets, using the
-    // extensions/ URLs. See catalog/sources.mjs.
     if (!inst.cachedExtensionCatalogSources?.length) {
         const extBootstrap = [
             {
@@ -212,10 +293,6 @@ async function hydrateOnce(inst) {
         inst.cachedExtensionCatalogSources = extBootstrap;
         await hydrateExtensionsForSources(inst, extBootstrap).catch(() => {});
     }
-    // Bundle catalog bootstrap — same pattern as extensions. The built-in
-    // `bundles/catalog.json` may 404 upstream; hydrateBundlesForSources
-    // logs the failure and continues so the community bundle catalog
-    // still populates the grid.
     if (!inst.cachedBundleCatalogSources?.length) {
         const bundleBootstrap = [
             {
@@ -238,13 +315,11 @@ async function hydrateOnce(inst) {
         inst.cachedBundleCatalogSources = bundleBootstrap;
         await hydrateBundlesForSources(inst, bundleBootstrap).catch(() => {});
     }
-    // Boot-time fast composition refresh so an existing worktree with
-    // presets/extensions already installed opens straight into the
-    // Composition tab with a hydrated composition slice. Silent on failure.
-    // TEMPORARY — remove with runFastComposition.
-    await runFastComposition(inst, { reason: "boot" });
-    await snapshot(inst);
 }
+
+// Legacy hydrateOnce removed — bootAsync in this file supersedes it. The
+// individual phases (hydrateReadState, hydrateCatalogs) are exported
+// internally for the retry/HTTP path.
 
 async function onClose(ctx) {
     const inst = instances.get(ctx.instanceId);

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/server.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/server.mjs
@@ -47,6 +47,7 @@ import {
     handleSkillsReload,
     handleProbeEnv,
 } from "./server/handlers-ops.mjs";
+import { handleNpmDiagnose, handleNpmRetry } from "./server/handlers-deps.mjs";
 import { ensureEnvProbe } from "./env/probe-cache.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -317,6 +318,8 @@ export function createHandler(deps) {
                     "/api/skills/reload": () => handleSkillsReload(res, { session, broadcast, getInstance }),
                     "/api/setup/skip-defaults": () => handleSkipDefaults(res, body, { broadcast, getInstance }),
                     "/api/env/probe": () => handleProbeEnv(res, { getState, broadcast, getInstance, ensureEnvProbe }),
+                    "/api/deps/diagnose": () => handleNpmDiagnose(res, body, { broadcast, getInstance }),
+                    "/api/deps/retry": () => handleNpmRetry(res, body, { broadcast, getInstance }),
                 };
                 const route = postRoutes[url.pathname];
                 if (route) return route();

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/server/handlers-deps.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/server/handlers-deps.mjs
@@ -1,0 +1,128 @@
+// HTTP endpoints for the boot-overlay's deps-error card.
+//
+//   POST /api/deps/diagnose  — dispatch the agent diagnostic prompt.
+//                              Mirrors the runSkillsReload/handleSkillsReload
+//                              split: the same underlying work is done by
+//                              the runNpmDiagnostics canvas action, so the
+//                              UI click and agent action share code.
+//   POST /api/deps/retry     — re-run installDeps, driving the boot tracker
+//                              so the overlay animates the retry inline.
+
+import { jsonRes, jsonError } from "./http-utils.mjs";
+import { buildNpmDiagnosticPrompt } from "../env/deps-recovery.mjs";
+import { dispatchPromptToSession } from "../canvas-runtime/dispatch.mjs";
+import { checkDeps, installDeps, getExtensionDir } from "../env/deps-check.mjs";
+import { createBootTracker } from "../canvas-runtime/boot-progress.mjs";
+import { snapshot } from "../canvas-runtime/snapshot.mjs";
+
+export async function handleNpmDiagnose(res, body, { broadcast, getInstance }) {
+    const inst = getInstance?.();
+    if (!inst) return jsonError(res, 400, "instance unavailable");
+    if (inst.depsDiagnoseInFlight) {
+        return jsonError(res, 409, "diagnose already in flight");
+    }
+    inst.depsDiagnoseInFlight = true;
+    try {
+        const cached = inst.depsError ?? null;
+        const errorCode = typeof body?.errorCode === "string" && body.errorCode.trim()
+            ? body.errorCode.trim()
+            : cached?.code ?? "UNKNOWN";
+        if (!cached && !body?.force) {
+            return jsonError(res, 400, "no cached deps error; pass force: true to dispatch anyway");
+        }
+        // Guard against stale-state re-dispatch: the cached depsError may
+        // be from a failure the user has since fixed manually. If deps are
+        // now installed, don't spam the agent — clear the record, broadcast
+        // the new state, and tell the client we resolved.
+        if (!body?.force) {
+            try {
+                const recheck = await checkDeps();
+                if (recheck.ready) {
+                    inst.depsError = null;
+                    try {
+                        const snap = await snapshot(inst);
+                        broadcast?.({ type: "state", data: snap });
+                    } catch { /* best-effort */ }
+                    return jsonRes(res, 200, { ok: true, resolved: true });
+                }
+            } catch { /* fall through and dispatch */ }
+        }
+        const prompt = buildNpmDiagnosticPrompt({
+            extDir: cached?.extDir ?? getExtensionDir(),
+            errorCode,
+            stderr: cached?.stderrTail ?? "",
+            workspacePath: inst.workspacePath ?? null,
+        });
+        dispatchPromptToSession({ prompt });
+        return jsonRes(res, 200, { ok: true, errorCode });
+    } finally {
+        // Release the guard after a short window so the button stays
+        // disabled long enough for the user to see the "dispatching" state
+        // but doesn't get permanently stuck if the client never rerenders.
+        setTimeout(() => { inst.depsDiagnoseInFlight = false; }, 1500);
+    }
+}
+
+export async function handleNpmRetry(res, body, { broadcast, getInstance }) {
+    const inst = getInstance?.();
+    if (!inst) return jsonError(res, 400, "instance unavailable");
+    if (inst.depsRetryInFlight) {
+        return jsonError(res, 409, "retry already in flight");
+    }
+    inst.depsRetryInFlight = true;
+    try {
+        // Recreate a tracker bound to the same inst.boot record so the UI
+        // sees the deps-install row animate again.
+        const tracker = createBootTracker({ broadcast, inst });
+        tracker.start("deps-install");
+
+        // Refresh missing set — some deps may already be installed if the user
+        // ran `npm install` manually since the failure.
+        const initial = await checkDeps();
+        if (initial.ready) {
+            tracker.ok("deps-install", { alreadyInstalled: true });
+            inst.depsError = null;
+            try {
+                const snap = await snapshot(inst);
+                broadcast?.({ type: "state", data: snap });
+            } catch { /* best-effort */ }
+            return jsonRes(res, 200, { ok: true, alreadyInstalled: true });
+        }
+
+        const installResult = await installDeps(initial.missing, {
+            onProgress: (line) => tracker.tick("deps-install", line),
+        });
+        const recheck = await checkDeps();
+        if (recheck.ready) {
+            tracker.ok("deps-install", { installed: initial.missing });
+            inst.depsError = null;
+            try {
+                const snap = await snapshot(inst);
+                broadcast?.({ type: "state", data: snap });
+            } catch { /* best-effort */ }
+            return jsonRes(res, 200, { ok: true, installed: initial.missing });
+        }
+        const classified = installResult.classified ?? {
+            code: "UNKNOWN",
+            title: "npm install failed",
+            hint: "The Copilot agent can help diagnose the failure.",
+            canRetry: true,
+        };
+        const stderrTail = String(installResult.stderr ?? "").split(/\r?\n/).filter(Boolean).slice(-8).join("\n");
+        inst.depsError = {
+            ...classified,
+            extDir: getExtensionDir(),
+            packages: initial.missing,
+            stderrTail,
+            timestamp: new Date().toISOString(),
+        };
+        tracker.fail("deps-install", { ...classified, stderrTail });
+        try {
+            const snap = await snapshot(inst);
+            broadcast?.({ type: "state", data: snap });
+        } catch { /* best-effort */ }
+        return jsonRes(res, 200, { ok: false, classified });
+    } finally {
+        inst.depsRetryInFlight = false;
+    }
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/boot-progress.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/boot-progress.test.mjs
@@ -1,0 +1,148 @@
+// Unit tests for canvas-runtime/boot-progress.mjs.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { createBootTracker, BOOT_STEPS } from "../canvas-runtime/boot-progress.mjs";
+
+function harness() {
+    const events = [];
+    const inst = {};
+    const tracker = createBootTracker({
+        broadcast: (msg) => events.push(msg),
+        inst,
+    });
+    return { tracker, inst, events };
+}
+
+test("BOOT_STEPS enumerates the expected ordered steps", () => {
+    assert.deepEqual(
+        BOOT_STEPS.map((s) => s.id),
+        ["workspace", "deps-check", "deps-install", "env-probe", "catalog", "ready"],
+    );
+});
+
+test("initial boot record: all steps pending, phase=booting", () => {
+    const { inst } = harness();
+    assert.equal(inst.boot.phase, "booting");
+    assert.ok(inst.boot.startedAt);
+    for (const s of inst.boot.steps) {
+        assert.equal(s.status, "pending");
+        assert.equal(s.startedAt, null);
+        assert.equal(s.durationMs, null);
+    }
+});
+
+test("start() marks step running and broadcasts snapshot", () => {
+    const { tracker, inst, events } = harness();
+    tracker.start("workspace");
+    const s = inst.boot.steps.find((x) => x.id === "workspace");
+    assert.equal(s.status, "running");
+    assert.ok(s.startedAt);
+    assert.equal(events.at(-1).type, "boot.update");
+});
+
+test("ok() marks running step ok with durationMs", async () => {
+    const { tracker, inst } = harness();
+    tracker.start("workspace");
+    await delay(5);
+    tracker.ok("workspace", { path: "/foo" });
+    const s = inst.boot.steps.find((x) => x.id === "workspace");
+    assert.equal(s.status, "ok");
+    assert.ok(s.endedAt);
+    assert.ok(s.durationMs >= 0);
+    assert.deepEqual(s.meta, { path: "/foo" });
+});
+
+test("fail() sets step failed and phase=failed with classified error", () => {
+    const { tracker, inst, events } = harness();
+    tracker.start("deps-install");
+    tracker.fail("deps-install", {
+        title: "npm can't reach the registry",
+        hint: "corp TLS?",
+        code: "TLS_HANDSHAKE",
+        canRetry: true,
+        stderrTail: "schannel: SEC_E_ILLEGAL_MESSAGE",
+    });
+    const s = inst.boot.steps.find((x) => x.id === "deps-install");
+    assert.equal(s.status, "failed");
+    assert.equal(s.error.code, "TLS_HANDSHAKE");
+    assert.equal(s.error.canRetry, true);
+    assert.match(s.error.stderrTail, /schannel/);
+    assert.equal(inst.boot.phase, "failed");
+    assert.equal(events.at(-1).boot.phase, "failed");
+});
+
+test("fail() accepts a bare string as the error title", () => {
+    const { tracker, inst } = harness();
+    tracker.start("deps-install");
+    tracker.fail("deps-install", "kablammo");
+    const s = inst.boot.steps.find((x) => x.id === "deps-install");
+    assert.equal(s.error.title, "kablammo");
+});
+
+test("skip() marks step skipped with a reason", () => {
+    const { tracker, inst } = harness();
+    tracker.skip("deps-install", "already-installed");
+    const s = inst.boot.steps.find((x) => x.id === "deps-install");
+    assert.equal(s.status, "skipped");
+    assert.deepEqual(s.meta, { reason: "already-installed" });
+});
+
+test("ready() marks the ready step ok and sets phase=ready", () => {
+    const { tracker, inst } = harness();
+    tracker.ready();
+    assert.equal(inst.boot.phase, "ready");
+    assert.equal(inst.boot.steps.at(-1).status, "ok");
+});
+
+test("tick() only records output when the step is running", () => {
+    const { tracker, inst } = harness();
+    tracker.tick("deps-install", "reify:js-yaml");
+    // step is pending, so tick is a no-op
+    assert.equal(inst.boot.steps.find((s) => s.id === "deps-install").output, null);
+    tracker.start("deps-install");
+    tracker.tick("deps-install", "reify:js-yaml");
+    assert.equal(inst.boot.steps.find((s) => s.id === "deps-install").output, "reify:js-yaml");
+});
+
+test("tick() throttles broadcasts but always keeps output current", async () => {
+    const { tracker, inst, events } = harness();
+    tracker.start("deps-install");
+    const before = events.length;
+    tracker.tick("deps-install", "line-1");
+    tracker.tick("deps-install", "line-2");
+    tracker.tick("deps-install", "line-3");
+    // First broadcast is immediate (last<0 → now-last>TICK_THROTTLE_MS).
+    // The subsequent ones coalesce into a single delayed emit.
+    const s = inst.boot.steps.find((x) => x.id === "deps-install");
+    assert.equal(s.output, "line-3");
+    // Wait past the throttle window; delayed emit should have fired.
+    await delay(300);
+    assert.ok(events.length - before >= 1);
+});
+
+test("snapshot() returns a deep clone; mutations do not affect state", () => {
+    const { tracker, inst } = harness();
+    tracker.start("workspace");
+    const snap = tracker.snapshot();
+    snap.phase = "explode";
+    snap.steps[0].status = "explode";
+    assert.equal(inst.boot.phase, "booting");
+    assert.equal(inst.boot.steps[0].status, "running");
+});
+
+test("createBootTracker requires inst", () => {
+    assert.throws(() => createBootTracker({ broadcast: () => {} }), /requires inst/);
+});
+
+test("preserves existing inst.boot on second create (retry path)", () => {
+    const events = [];
+    const inst = {};
+    const t1 = createBootTracker({ broadcast: (m) => events.push(m), inst });
+    t1.start("workspace");
+    t1.ok("workspace");
+    const t2 = createBootTracker({ broadcast: (m) => events.push(m), inst });
+    const s = t2.snapshot().steps.find((x) => x.id === "workspace");
+    assert.equal(s.status, "ok");
+});

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/deps-error-classifier.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/deps-error-classifier.test.mjs
@@ -1,0 +1,78 @@
+// Unit tests for env/deps-error-classifier.mjs.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { classifyNpmError } from "../env/deps-error-classifier.mjs";
+
+test("NPM_MISSING wins when missingBinary is true, regardless of stderr", () => {
+    const c = classifyNpmError({ missingBinary: true, stderr: "anything" });
+    assert.equal(c.code, "NPM_MISSING");
+    assert.equal(c.canRetry, false);
+    assert.match(c.title, /npm/);
+});
+
+test("classifies schannel handshake failures as TLS_HANDSHAKE", () => {
+    const c = classifyNpmError({
+        stderr: "npm ERR! request to https://registry.npmjs.org/js-yaml failed, reason: schannel: SEC_E_ILLEGAL_MESSAGE",
+    });
+    assert.equal(c.code, "TLS_HANDSHAKE");
+    assert.equal(c.canRetry, true);
+});
+
+test("classifies OpenSSL handshake failures as TLS_HANDSHAKE", () => {
+    const c = classifyNpmError({
+        stderr: "SSL routines::ssl3_read_bytes:tlsv1 alert handshake failure",
+    });
+    assert.equal(c.code, "TLS_HANDSHAKE");
+});
+
+test("classifies self-signed cert chain errors as CERT_UNTRUSTED", () => {
+    const c = classifyNpmError({
+        stderr: "npm ERR! request to https://registry.npmjs.org failed, reason: self signed certificate in certificate chain SELF_SIGNED_CERT_IN_CHAIN",
+    });
+    assert.equal(c.code, "CERT_UNTRUSTED");
+});
+
+test("classifies HTTP 407 proxy-auth as HTTP_407_PROXY", () => {
+    const c = classifyNpmError({
+        stderr: "npm ERR! code E407\nnpm ERR! 407 Proxy Authentication Required",
+    });
+    assert.equal(c.code, "HTTP_407_PROXY");
+});
+
+test("classifies HTTP 403 as HTTP_403", () => {
+    const c = classifyNpmError({
+        stderr: "npm ERR! code E403\nnpm ERR! 403 Forbidden - GET https://registry.npmjs.org/js-yaml",
+    });
+    assert.equal(c.code, "HTTP_403");
+});
+
+test("classifies ECONNREFUSED as CONN_REFUSED", () => {
+    const c = classifyNpmError({
+        stderr: "npm ERR! network request to https://registry.npmjs.org failed, reason: connect ECONNREFUSED 127.0.0.1:443",
+    });
+    assert.equal(c.code, "CONN_REFUSED");
+});
+
+test("classifies ENOTFOUND as DNS_UNRESOLVED", () => {
+    const c = classifyNpmError({
+        stderr: "npm ERR! network request failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org",
+    });
+    assert.equal(c.code, "DNS_UNRESOLVED");
+});
+
+test("falls back to UNKNOWN for opaque failures", () => {
+    const c = classifyNpmError({ stderr: "npm ERR! something odd", code: 1 });
+    assert.equal(c.code, "UNKNOWN");
+    assert.equal(c.canRetry, true);
+    assert.ok(c.title);
+    assert.ok(c.hint);
+});
+
+test("empty input still returns a well-formed record", () => {
+    const c = classifyNpmError({});
+    assert.equal(c.code, "UNKNOWN");
+    assert.ok(typeof c.title === "string");
+    assert.ok(typeof c.hint === "string");
+    assert.equal(typeof c.canRetry, "boolean");
+});

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/deps-recovery.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/deps-recovery.test.mjs
@@ -1,0 +1,70 @@
+// Unit tests for env/deps-recovery.mjs.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildNpmDiagnosticPrompt } from "../env/deps-recovery.mjs";
+
+test("throws when extDir is missing", () => {
+    assert.throws(
+        () => buildNpmDiagnosticPrompt({ errorCode: "UNKNOWN" }),
+        /requires extDir/,
+    );
+});
+
+test("includes extDir verbatim in the retry step", () => {
+    const p = buildNpmDiagnosticPrompt({
+        extDir: "C:\\Users\\me\\ext",
+        errorCode: "TLS_HANDSHAKE",
+        stderr: "schannel: SEC_E_ILLEGAL_MESSAGE",
+    });
+    assert.ok(p.includes("C:\\Users\\me\\ext"));
+    assert.match(p, /npm install --no-audit --no-fund/);
+});
+
+test("mentions the classified error code and includes a code-specific hint", () => {
+    const tls = buildNpmDiagnosticPrompt({
+        extDir: "/x",
+        errorCode: "TLS_HANDSHAKE",
+        stderr: "",
+    });
+    assert.match(tls, /TLS_HANDSHAKE/);
+    assert.match(tls, /Focus on TLS/);
+
+    const cert = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "CERT_UNTRUSTED" });
+    assert.match(cert, /Focus on certificates/);
+
+    const proxy = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "HTTP_407_PROXY" });
+    assert.match(proxy, /Focus on proxy/);
+
+    const dns = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "DNS_UNRESOLVED" });
+    assert.match(dns, /Focus on DNS/);
+
+    const missing = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "NPM_MISSING" });
+    assert.match(missing, /npm is not installed|not on PATH/);
+});
+
+test("falls back to UNKNOWN hint for unknown codes", () => {
+    const p = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "SOMETHING_ELSE" });
+    assert.match(p, /did not match a known pattern/);
+});
+
+test("truncates very long stderr", () => {
+    const long = "x".repeat(5000);
+    const p = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "UNKNOWN", stderr: long });
+    assert.ok(p.includes("(truncated)"));
+    assert.ok(p.length < long.length + 2000);
+});
+
+test("workspacePath appears when provided", () => {
+    const p = buildNpmDiagnosticPrompt({
+        extDir: "/x",
+        errorCode: "UNKNOWN",
+        workspacePath: "/home/nicole/repo",
+    });
+    assert.match(p, /User workspace: \/home\/nicole\/repo/);
+});
+
+test("prompt tells the agent to call refreshEnvironment on success", () => {
+    const p = buildNpmDiagnosticPrompt({ extDir: "/x", errorCode: "UNKNOWN" });
+    assert.match(p, /refreshEnvironment/);
+});

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/app.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/app.js
@@ -17,6 +17,7 @@ import {
     handleServerMessage,
     renderCwd,
 } from "./client.js";
+import { installBootOverlay } from "./boot.js";
 import {
     setViewersDeps,
     openArtifactViewer,
@@ -96,7 +97,8 @@ setPhaseCardDeps({ renderGraphPhaseCard });
 setGraphPhaseCardDeps({ postJson, openArtifactViewer, openCommandViewer, renderPhaseCard, renderStepper });
 setEnvDeps({ postJson });
 setViewersDeps({ postJson, HEADERS });
-setMessagesDeps({ render, refreshState });
+const boot = installBootOverlay({ token: TOKEN });
+setMessagesDeps({ render, refreshState, onBoot: boot.handleBootMessage });
 
 // -------- Boot --------
 // init() runs at the bottom of the module to avoid TDZ errors when init
@@ -136,12 +138,33 @@ function selectTab(name) {
 }
 
 // -------- Theme --------
+const THEME_STORAGE_KEY = "speckit-wizard.theme";
+
+function currentTheme() {
+    const explicit = document.documentElement.getAttribute("data-theme");
+    if (explicit === "dark" || explicit === "light") return explicit;
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    const btn = document.getElementById("theme-toggle");
+    if (btn) {
+        btn.textContent = theme === "dark" ? "☾" : "☀";
+        btn.setAttribute("aria-label", theme === "dark" ? "Switch to light theme" : "Switch to dark theme");
+        btn.setAttribute("title", theme === "dark" ? "Switch to light theme" : "Switch to dark theme");
+    }
+}
+
 function wireThemeToggle() {
+    let stored = null;
+    try { stored = localStorage.getItem(THEME_STORAGE_KEY); } catch { /* ignore */ }
+    applyTheme(stored === "dark" || stored === "light" ? stored : currentTheme());
     const btn = document.getElementById("theme-toggle");
     btn?.addEventListener("click", () => {
-        const cur = document.documentElement.getAttribute("data-theme");
-        const next = cur === "dark" ? "light" : "dark";
-        document.documentElement.setAttribute("data-theme", next);
+        const next = currentTheme() === "dark" ? "light" : "dark";
+        applyTheme(next);
+        try { localStorage.setItem(THEME_STORAGE_KEY, next); } catch { /* ignore */ }
     });
 }
 
@@ -216,6 +239,10 @@ async function refreshState() {
         if (!res.ok) throw new Error(`state ${res.status}`);
         const snap = await res.json();
         state.snapshot = snap;
+        // Seed boot overlay from initial snapshot so the panel reflects
+        // any progress the backend has made between server-start and
+        // this first REST fetch (avoids a blank frame before SSE ticks).
+        boot.setInitialSnapshot(snap);
         const cp = snap.currentPhase || "constitution";
         state.currentPhase = SETUP_TAB_PHASE_KEYS.has(cp) ? "constitution" : cp;
         render();

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/boot.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/boot.js
@@ -1,0 +1,382 @@
+// Boot overlay module. Renders a live checklist of the wizard backend's
+// startup steps, updated over SSE. Self-contained; no dependency on the
+// main app modules — bootstraps and tears down before the app takes over.
+//
+// Wire-in points:
+//   - ui/index.html has <div id="boot-overlay"></div> + <link boot.css>.
+//   - ui/app.js imports installBootOverlay() and calls it before any
+//     other module initialization; the overlay hides itself once the
+//     backend reports `boot.phase === "ready"`.
+//   - ui/client.js dispatches `boot.update` messages here via
+//     handleBootMessage() (registered by installBootOverlay).
+
+const STEP_LABELS = {
+    workspace: "Resolving project",
+    "deps-check": "Checking dependencies",
+    "deps-install": "Installing dependencies",
+    "env-probe": "Probing environment",
+    catalog: "Loading catalogs",
+    ready: "Ready",
+};
+
+// SSE token needed for /api/deps/{diagnose,retry} POST. app.js sets it.
+let __token = null;
+let __root = null;
+let __state = { phase: null, steps: [] };
+let __depsError = null;
+let __appRootEl = null;
+let __banner = null;
+// Module-level pending state so re-renders (which reset the DOM every SSE
+// tick) preserve the "button was clicked, response pending" visual state.
+// Otherwise a snapshot broadcast a few ms after the click re-enables the
+// button and the user can double-fire retry/diagnose.
+let __pending = { retry: false, diagnose: false };
+// Once the user dismisses the in-app banner for a given error timestamp,
+// remember it so subsequent SSE ticks don't re-open it. A new failure
+// (different timestamp) will still surface.
+let __bannerDismissedFor = null;
+// User elected to bypass the frozen boot dialog (deps still failed but they
+// want to try the wizard anyway). Keyed by timestamp so a fresh failure
+// re-freezes the boot dialog instead of silently reusing this decision.
+let __continueAnywayFor = null;
+
+// Runtime dependencies the extension needs to fully function. Surfaced in
+// the in-wizard banner as a copy/paste-friendly install command. Keep in
+// sync with package.json.
+const RUNTIME_DEP_PACKAGES = ["js-yaml"];
+
+export function installBootOverlay({ token }) {
+    __token = token || null;
+    __root = document.getElementById("boot-overlay");
+    if (!__root) return { handleBootMessage: () => {}, setInitialSnapshot: () => {} };
+    __appRootEl = document.querySelector("main.app-body");
+    if (__appRootEl) __appRootEl.style.visibility = "hidden";
+    render();
+    return {
+        handleBootMessage,
+        setInitialSnapshot,
+        setDepsError,
+    };
+}
+
+// Called by app.js after the first REST snapshot arrives, so the overlay
+// reflects whatever progress the server has already made (avoids a
+// blank frame while we wait for the first SSE tick).
+export function setInitialSnapshot(snapshot) {
+    if (!snapshot) return;
+    if (snapshot.boot) __state = snapshot.boot;
+    if (snapshot.depsError) __depsError = snapshot.depsError;
+    render();
+}
+
+export function setDepsError(err) {
+    __depsError = err ?? null;
+    render();
+}
+
+export function handleBootMessage(msg) {
+    if (!msg || typeof msg !== "object") return;
+    if (msg.type !== "boot.update") return;
+    if (msg.boot) __state = msg.boot;
+    if (msg.depsError !== undefined) __depsError = msg.depsError;
+    render();
+}
+
+function render() {
+    if (!__root) return;
+
+    // Ready → normally fade the overlay out. BUT when a deps error is
+    // active we freeze the boot dialog so the user can troubleshoot with
+    // the agent, retry, or explicitly opt into continuing. Once they click
+    // "Continue" (which sets __continueAnywayFor for this error
+    // timestamp), the overlay dismisses regardless of the boot phase —
+    // the pipeline can be stuck at deps-install and never reach "ready",
+    // but the user has explicitly chosen to move on. A prominent in-wizard
+    // banner then spells out the manual fix.
+    const errTs = __depsError?.timestamp ?? null;
+    const bypassed = __depsError && __continueAnywayFor === errTs;
+    const shouldHideOverlay = bypassed || (__state?.phase === "ready" && !__depsError);
+
+    if (shouldHideOverlay) {
+        if (!__root.classList.contains("is-hidden")) {
+            __root.classList.add("is-hidden");
+            setTimeout(() => {
+                // Recompute the guard inside the timeout — if a fresh error
+                // arrived during the fade we need to snap back into the
+                // frozen overlay instead of hiding it out from under the user.
+                const stillBypassed = __depsError && __continueAnywayFor === __depsError.timestamp;
+                const stillReady = __state?.phase === "ready" && !__depsError;
+                if (__root && (stillBypassed || stillReady)) {
+                    __root.style.display = "none";
+                    if (__appRootEl) __appRootEl.style.visibility = "";
+                }
+            }, 320);
+        }
+        renderBanner();
+        return;
+    }
+    // Overlay still owning the screen: keep the banner hidden.
+    hideBanner();
+
+    __root.style.display = "";
+    __root.classList.remove("is-hidden");
+    __root.className = "boot-overlay";
+    __root.innerHTML = "";
+
+    const panel = document.createElement("div");
+    panel.className = "boot-panel";
+
+    const title = document.createElement("h1");
+    title.className = "boot-title";
+    title.innerHTML = '<span class="boot-title-mark" aria-hidden="true">◈</span>Starting Spec Kit Wizard';
+    panel.appendChild(title);
+
+    const subtitle = document.createElement("p");
+    subtitle.className = "boot-subtitle";
+    subtitle.textContent = "Preparing your project…";
+    panel.appendChild(subtitle);
+
+    const list = document.createElement("ul");
+    list.className = "boot-steps";
+    for (const step of __state?.steps ?? []) {
+        list.appendChild(renderStep(step));
+    }
+    panel.appendChild(list);
+
+    if (__depsError) {
+        panel.appendChild(renderErrorCard(__depsError));
+    }
+
+    __root.appendChild(panel);
+}
+
+// Prominent in-wizard alert shown once the user has explicitly bypassed the
+// boot dialog (Continue anyway) or after a fresh error while the overlay is
+// mid-fade. Includes an actionable manual-install command + extension path
+// so the user can fix it themselves in a terminal. Dismiss × drops it for
+// this error instance only.
+function renderBanner() {
+    if (!__depsError || __bannerDismissedFor === __depsError.timestamp) {
+        hideBanner();
+        return;
+    }
+    if (!__banner) {
+        __banner = document.createElement("div");
+        __banner.className = "deps-error-banner";
+        __banner.setAttribute("role", "alert");
+        const host = __appRootEl?.parentNode ?? document.body;
+        host.insertBefore(__banner, __appRootEl ?? null);
+    }
+    __banner.innerHTML = "";
+
+    const icon = document.createElement("span");
+    icon.className = "deps-error-banner-icon";
+    icon.setAttribute("aria-hidden", "true");
+    icon.textContent = "⚠";
+    __banner.appendChild(icon);
+
+    const body = document.createElement("div");
+    body.className = "deps-error-banner-body";
+
+    const title = document.createElement("div");
+    title.className = "deps-error-banner-title";
+    title.textContent = "Missing dependency: " + RUNTIME_DEP_PACKAGES.join(", ");
+    body.appendChild(title);
+
+    const msg = document.createElement("div");
+    msg.className = "deps-error-banner-msg";
+    msg.textContent = "Some wizard features (catalog parsing, preset details) may not work. To fix, install the package manually and reload this canvas.";
+    body.appendChild(msg);
+
+    const steps = document.createElement("ol");
+    steps.className = "deps-error-banner-steps";
+
+    const step1 = document.createElement("li");
+    step1.textContent = "Open a terminal in the extension folder:";
+    const path = document.createElement("code");
+    path.className = "deps-error-banner-path";
+    path.textContent = __depsError.extDir || "(extension folder)";
+    step1.appendChild(document.createElement("br"));
+    step1.appendChild(path);
+    steps.appendChild(step1);
+
+    const step2 = document.createElement("li");
+    const cmdWrap = document.createElement("span");
+    cmdWrap.textContent = "Run: ";
+    const cmd = document.createElement("code");
+    cmd.className = "deps-error-banner-cmd";
+    cmd.textContent = "npm install " + RUNTIME_DEP_PACKAGES.join(" ");
+    cmdWrap.appendChild(cmd);
+    step2.appendChild(cmdWrap);
+    steps.appendChild(step2);
+
+    const step3 = document.createElement("li");
+    step3.textContent = "Close and reopen this canvas panel.";
+    steps.appendChild(step3);
+
+    body.appendChild(steps);
+    __banner.appendChild(body);
+
+    const dismiss = document.createElement("button");
+    dismiss.type = "button";
+    dismiss.className = "deps-error-banner-dismiss";
+    dismiss.setAttribute("aria-label", "Dismiss");
+    dismiss.title = "Dismiss";
+    dismiss.textContent = "×";
+    dismiss.addEventListener("click", () => {
+        __bannerDismissedFor = __depsError?.timestamp ?? "dismissed";
+        hideBanner();
+    });
+    __banner.appendChild(dismiss);
+
+    __banner.style.display = "";
+}
+
+function hideBanner() {
+    if (__banner) __banner.style.display = "none";
+}
+
+function renderStep(step) {
+    const li = document.createElement("li");
+    li.className = "boot-step";
+    li.dataset.status = step.status || "pending";
+    li.dataset.step = step.id;
+
+    const icon = document.createElement("span");
+    icon.className = "boot-step-icon";
+    icon.setAttribute("aria-hidden", "true");
+    li.appendChild(icon);
+
+    const label = document.createElement("div");
+    const labelText = document.createElement("span");
+    labelText.className = "boot-step-label";
+    labelText.textContent = STEP_LABELS[step.id] || step.id;
+    label.appendChild(labelText);
+
+    // Prefer `output` (live per-line updates written by tracker.tick()) and
+    // fall back to `detail` for compatibility with any callers that set it
+    // directly. Without this, the throttled live npm output emitted over
+    // SSE would never render in the checklist.
+    const detailText = step.output || step.detail || "";
+    if (detailText) {
+        const detail = document.createElement("span");
+        detail.className = "boot-step-detail";
+        detail.textContent = detailText;
+        label.appendChild(detail);
+    }
+    li.appendChild(label);
+
+    return li;
+}
+
+function renderErrorCard(err) {
+    const card = document.createElement("div");
+    card.className = "boot-error-card";
+
+    const title = document.createElement("h2");
+    title.className = "boot-error-title";
+    title.textContent = err.title || "Dependency install failed";
+    card.appendChild(title);
+
+    const hint = document.createElement("p");
+    hint.className = "boot-error-hint";
+    hint.textContent = err.hint || "The Copilot agent can help diagnose the failure.";
+    card.appendChild(hint);
+
+    if (err.stderrTail) {
+        const pre = document.createElement("pre");
+        pre.className = "boot-error-stderr";
+        pre.textContent = err.stderrTail;
+        card.appendChild(pre);
+    }
+
+    const actions = document.createElement("div");
+    actions.className = "boot-error-actions";
+
+    const diagnose = document.createElement("button");
+    diagnose.type = "button";
+    diagnose.className = "boot-btn boot-btn-primary";
+    if (__pending.diagnose) {
+        diagnose.disabled = true;
+        diagnose.textContent = "Dispatching to agent…";
+    } else {
+        diagnose.textContent = "Diagnose and fix with the agent";
+    }
+    diagnose.addEventListener("click", () => {
+        if (__pending.diagnose) return;
+        __pending.diagnose = true;
+        diagnose.disabled = true;
+        diagnose.textContent = "Dispatching to agent…";
+        callDeps("/api/deps/diagnose", { errorCode: err.code }).finally(() => {
+            __pending.diagnose = false;
+            // Force a re-render so any concurrently disabled UI unlocks.
+            render();
+        });
+    });
+    actions.appendChild(diagnose);
+
+    if (err.canRetry !== false) {
+        const retry = document.createElement("button");
+        retry.type = "button";
+        retry.className = "boot-btn boot-btn-secondary";
+        if (__pending.retry) {
+            retry.disabled = true;
+            retry.textContent = "Retrying…";
+        } else {
+            retry.textContent = "Retry install";
+        }
+        retry.addEventListener("click", () => {
+            if (__pending.retry) return;
+            __pending.retry = true;
+            retry.disabled = true;
+            retry.textContent = "Retrying…";
+            callDeps("/api/deps/retry", {}).finally(() => {
+                __pending.retry = false;
+                render();
+            });
+        });
+        actions.appendChild(retry);
+    }
+
+    // Escape hatch: user has read the failure and wants to try the wizard
+    // anyway. Marks this specific error timestamp as bypassed so render()
+    // will finally hide the overlay — regardless of whether the backend's
+    // boot pipeline ever reached "ready" (installDeps re-runs npm install
+    // and can stay stuck on network errors indefinitely, so we can't gate
+    // on phase). The in-wizard banner will spell out the manual fix. A
+    // fresh failure (new timestamp) re-freezes.
+    //
+    // This button is intentionally NEVER disabled, even mid-dispatch of
+    // Diagnose or Retry — it's the user's only guaranteed way out of the
+    // frozen dialog.
+    const proceed = document.createElement("button");
+    proceed.type = "button";
+    proceed.className = "boot-btn boot-btn-tertiary";
+    proceed.textContent = "Continue";
+    proceed.title = "Open the wizard without installing dependencies. Some features may not work.";
+    proceed.addEventListener("click", () => {
+        __continueAnywayFor = err.timestamp ?? "bypassed";
+        render();
+    });
+    actions.appendChild(proceed);
+
+    const proceedNote = document.createElement("p");
+    proceedNote.className = "boot-error-proceed-note";
+    proceedNote.textContent = "If you continue, you'll need to run `npm install " + RUNTIME_DEP_PACKAGES.join(" ") + "` manually and reload the canvas for full functionality.";
+    card.appendChild(proceedNote);
+
+    card.appendChild(actions);
+    return card;
+}
+
+async function callDeps(path, body) {
+    const headers = { "Content-Type": "application/json" };
+    if (__token) headers["X-Canvas-Token"] = __token;
+    const res = await fetch(path, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body || {}),
+    });
+    return res.json().catch(() => ({}));
+}
+

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/client.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/client.js
@@ -206,19 +206,37 @@ export function resolveSnapshotWaiters() {
 
 let __render = () => {};
 let __refreshState = async () => {};
+let __onBoot = () => {};
 
-export function setMessagesDeps({ render, refreshState } = {}) {
+export function setMessagesDeps({ render, refreshState, onBoot } = {}) {
     if (typeof render === "function") __render = render;
     if (typeof refreshState === "function") __refreshState = refreshState;
+    if (typeof onBoot === "function") __onBoot = onBoot;
 }
 export function handleServerMessage(msg) {
     switch (msg.type) {
+        case "boot.update":
+            __onBoot(msg);
+            // Boot updates also carry live snapshot fragments; forward
+            // depsError so the state snapshot stays in sync when the
+            // main UI eventually renders.
+            if (state.snapshot) {
+                if (msg.boot !== undefined) state.snapshot.boot = msg.boot;
+                if (msg.depsError !== undefined) state.snapshot.depsError = msg.depsError;
+            }
+            break;
         case "state":
             // A reconnect or legacy broadcaster can emit a state envelope
             // without a usable snapshot. Never replace a valid UI state with
             // undefined; the next valid broadcast or refresh will repair it.
             if (!msg.data || typeof msg.data !== "object") break;
             state.snapshot = msg.data;
+            // Forward boot progress to the overlay whenever a state
+            // broadcast arrives — SSE state envelopes include boot +
+            // depsError as inline fields (snapshot builder overlay).
+            if (msg.data.boot !== undefined || msg.data.depsError !== undefined) {
+                __onBoot({ type: "boot.update", boot: msg.data.boot ?? null, depsError: msg.data.depsError ?? null });
+            }
             // Preserve local navigation. The user's active phase is a UI
             // concern; a state broadcast triggered by an artifact write
             // (or any background refresh) must not yank them back to

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/index.html
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/index.html
@@ -12,8 +12,10 @@
         <link rel="stylesheet" href="/ui/styles/setup-substeps.css" />
         <link rel="stylesheet" href="/ui/styles/pipeline.css" />
         <link rel="stylesheet" href="/ui/styles/overlays.css" />
+        <link rel="stylesheet" href="/ui/styles/boot.css" />
     </head>
     <body>
+        <div id="boot-overlay"></div>
         <header class="app-header">
             <div class="brand">
                 <span class="brand-mark" aria-hidden="true">◈</span>

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/styles/boot.css
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/styles/boot.css
@@ -1,0 +1,353 @@
+/* Boot overlay — full-viewport panel shown while the wizard's per-instance
+   backend runs its startup checklist (workspace → deps-check → deps-install
+   → env-probe → catalog → ready). Self-contained; no dependency on any
+   other stylesheet. */
+
+/* Theme variables — default (light). Foundation.css sets data-theme on <html>
+   from OS preference or the theme toggle; we redefine our local vars there. */
+.boot-overlay {
+    --boot-surface-base: #f7f8fb;
+    --boot-surface-panel: #ffffff;
+    --boot-border: #d5d9e0;
+    --boot-text: #171a2c;
+    --boot-text-muted: #5a5f76;
+    --boot-accent: #0b6e99;
+    --boot-success: #178c4e;
+    --boot-danger: #c7362e;
+    --boot-danger-tint: rgba(199, 54, 46, 0.08);
+    --boot-running-tint: rgba(11, 110, 153, 0.08);
+    --boot-panel-shadow: 0 12px 40px rgba(0, 0, 0, 0.10);
+    --boot-stderr-bg: #f3f1ea;
+}
+
+[data-theme="dark"] .boot-overlay,
+:root:not([data-theme]) .boot-overlay {
+    /* fallback dark values used when the toggle explicitly says dark, or when
+       nothing is set yet — the @media below overrides the second case for OS
+       light-mode users. */
+    --boot-surface-base: #0f1420;
+    --boot-surface-panel: #171d2c;
+    --boot-border: #2a3348;
+    --boot-text: #e8ecf3;
+    --boot-text-muted: #98a2b8;
+    --boot-accent: #60a5fa;
+    --boot-success: #4cd08b;
+    --boot-danger: #ef4444;
+    --boot-danger-tint: rgba(239, 68, 68, 0.08);
+    --boot-running-tint: rgba(96, 165, 250, 0.08);
+    --boot-panel-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+    --boot-stderr-bg: rgba(0, 0, 0, 0.35);
+}
+
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) .boot-overlay {
+        --boot-surface-base: #f7f8fb;
+        --boot-surface-panel: #ffffff;
+        --boot-border: #d5d9e0;
+        --boot-text: #171a2c;
+        --boot-text-muted: #5a5f76;
+        --boot-accent: #0b6e99;
+        --boot-success: #178c4e;
+        --boot-danger: #c7362e;
+        --boot-danger-tint: rgba(199, 54, 46, 0.08);
+        --boot-running-tint: rgba(11, 110, 153, 0.08);
+        --boot-panel-shadow: 0 12px 40px rgba(0, 0, 0, 0.10);
+        --boot-stderr-bg: #f3f1ea;
+    }
+}
+
+.boot-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: var(--boot-surface-base);
+    color: var(--boot-text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    transition: opacity 300ms ease-out;
+}
+
+.boot-overlay.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.boot-panel {
+    width: 100%;
+    max-width: 520px;
+    background: var(--boot-surface-panel);
+    border: 1px solid var(--boot-border);
+    border-radius: 12px;
+    padding: 24px 28px;
+    box-shadow: var(--boot-panel-shadow);
+}
+
+.boot-title {
+    margin: 0 0 4px 0;
+    font-size: 18px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.boot-title-mark {
+    font-size: 20px;
+    color: var(--boot-accent);
+}
+
+.boot-subtitle {
+    margin: 0 0 20px 0;
+    font-size: 13px;
+    color: var(--boot-text-muted);
+}
+
+.boot-steps {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.boot-step {
+    display: grid;
+    grid-template-columns: 20px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 10px;
+    border-radius: 6px;
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.boot-step-icon {
+    width: 20px;
+    height: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+}
+
+.boot-step-label {
+    color: var(--boot-text);
+    font-weight: 500;
+}
+
+.boot-step-detail {
+    color: var(--boot-text-muted);
+    font-size: 11px;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 240px;
+    display: block;
+    margin-top: 2px;
+}
+
+.boot-step[data-status="pending"] .boot-step-icon { color: var(--boot-text-muted); }
+.boot-step[data-status="pending"] .boot-step-icon::before { content: "○"; }
+.boot-step[data-status="pending"] .boot-step-label { color: var(--boot-text-muted); }
+
+.boot-step[data-status="running"] { background: var(--boot-running-tint); }
+.boot-step[data-status="running"] .boot-step-icon::before {
+    content: "";
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--boot-accent);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: boot-spin 900ms linear infinite;
+}
+
+.boot-step[data-status="ok"] .boot-step-icon { color: var(--boot-success); }
+.boot-step[data-status="ok"] .boot-step-icon::before { content: "✓"; font-weight: 700; }
+
+.boot-step[data-status="skipped"] .boot-step-icon { color: var(--boot-text-muted); }
+.boot-step[data-status="skipped"] .boot-step-icon::before { content: "–"; }
+
+.boot-step[data-status="failed"] .boot-step-icon { color: var(--boot-danger); }
+.boot-step[data-status="failed"] .boot-step-icon::before { content: "✕"; font-weight: 700; }
+.boot-step[data-status="failed"] { background: var(--boot-danger-tint); }
+
+.boot-error-card {
+    margin-top: 16px;
+    padding: 14px 16px;
+    border: 1px solid var(--boot-danger);
+    background: var(--boot-danger-tint);
+    border-radius: 8px;
+}
+
+.boot-error-title {
+    margin: 0 0 4px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--boot-danger);
+}
+
+.boot-error-hint {
+    margin: 0 0 12px 0;
+    font-size: 13px;
+    color: var(--boot-text);
+    line-height: 1.5;
+}
+
+.boot-error-stderr {
+    margin: 8px 0 12px 0;
+    padding: 8px 10px;
+    background: var(--boot-stderr-bg);
+    border-radius: 4px;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: var(--boot-text-muted);
+    max-height: 100px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.boot-error-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.boot-btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid transparent;
+    font-family: inherit;
+}
+
+.boot-btn-primary {
+    background: var(--boot-accent);
+    color: var(--boot-surface-panel);
+    border-color: var(--boot-accent);
+}
+
+.boot-btn-primary:hover { filter: brightness(1.08); }
+
+.boot-btn-secondary {
+    background: transparent;
+    color: var(--boot-text);
+    border-color: var(--boot-border);
+}
+
+.boot-btn-secondary:hover { background: var(--boot-running-tint); }
+
+.boot-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+@keyframes boot-spin {
+    to { transform: rotate(360deg); }
+}
+
+
+/* Prominent dismissible alert shown at the top of the wizard body after
+ * the user opts to Continue anyway from the boot dialog (or a fresh
+ * failure surfaces post-boot). Multi-line layout with an actionable
+ * manual-install command + extension path. */
+.deps-error-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--boot-danger-tint);
+    border-bottom: 2px solid var(--boot-danger);
+    color: var(--boot-text);
+    font-size: 13px;
+    line-height: 1.5;
+}
+.deps-error-banner-icon {
+    color: var(--boot-danger);
+    font-size: 18px;
+    line-height: 1.2;
+    flex: 0 0 auto;
+}
+.deps-error-banner-body {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.deps-error-banner-title {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--boot-text);
+    margin-bottom: 4px;
+}
+.deps-error-banner-msg {
+    color: var(--boot-text);
+    margin-bottom: 8px;
+}
+.deps-error-banner-steps {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--boot-text);
+}
+.deps-error-banner-steps li {
+    margin: 4px 0;
+}
+.deps-error-banner-path,
+.deps-error-banner-cmd {
+    display: inline-block;
+    background: var(--boot-surface-panel);
+    border: 1px solid var(--boot-border);
+    border-radius: 3px;
+    padding: 2px 6px;
+    font-family: ui-monospace, "Cascadia Code", "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 12px;
+    color: var(--boot-text);
+    white-space: nowrap;
+    max-width: 100%;
+    overflow-x: auto;
+    vertical-align: middle;
+}
+.deps-error-banner-path {
+    margin-top: 2px;
+}
+.deps-error-banner-dismiss {
+    background: transparent;
+    border: 0;
+    color: var(--boot-text-muted);
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 4px;
+    flex: 0 0 auto;
+    align-self: flex-start;
+}
+.deps-error-banner-dismiss:hover { color: var(--boot-text); }
+
+/* Tertiary "Continue anyway" action on the boot overlay error card —
+ * lower-emphasis than Diagnose (primary) or Retry (secondary). */
+.boot-btn-tertiary {
+    background: transparent;
+    color: var(--boot-text-muted);
+    border: 1px solid var(--boot-border);
+}
+.boot-btn-tertiary:hover:not(:disabled) {
+    color: var(--boot-text);
+    border-color: var(--boot-text-muted);
+}
+.boot-error-proceed-note {
+    margin: 8px 0 0;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: var(--boot-text-muted);
+    background: var(--boot-surface-panel);
+    border: 1px dashed var(--boot-border);
+    border-radius: 4px;
+}
+.boot-error-proceed-note code {
+    font-family: ui-monospace, "Cascadia Code", "SFMono-Regular", Menlo, Consolas, monospace;
+    font-size: 11.5px;
+}


### PR DESCRIPTION
Adds live boot-progress plumbing to the Spec Kit Wizard canvas extension and an agent-assisted recovery flow for dependency-install failures (js-yaml).

## What's new

**Live boot progress overlay** (`ui/boot.js`, `ui/styles/boot.css`, `canvas-runtime/boot-progress.mjs`)
- SSE-driven checklist of backend startup steps: `workspace -> deps-check -> deps-install -> env-probe -> catalog -> ready`.
- Overlay hides once the backend is ready and hands off to the wizard body.

**Deps-error UX** (redesigned across several iterations in this PR)
- Boot overlay **freezes** on `deps-install` failure so the user is never dropped into a broken wizard.
- Three actions on the frozen dialog:
  - **Diagnose and fix with the agent** (primary) - dispatches a classified checklist prompt back to the parent Copilot session.
  - **Retry install** (secondary) - hits `/api/deps/retry`, re-checks deps, auto-clears cached error if user fixed things externally.
  - **Continue** (tertiary, always enabled) - escape hatch. Short-circuits the phase gate so the overlay dismisses even when `installDeps` is stuck on a broken registry.
- After Continue, a prominent in-wizard banner shows the manual fix: missing package name, exact `npm install js-yaml` command, extension folder path, reload instruction, dismissible.

**Server-side hardening**
- Concurrent in-flight guards on diagnose/retry (409 with try/finally).
- Diagnose re-checks deps before dispatching to avoid stale-state prompt loops.
- npm error classifier maps common failure modes to actionable titles + hints.
- `truncateStderr` escapes triple-backticks to defuse prompt injection.

**Bug fixes**
- `X-Wizard-Token` -> `X-Canvas-Token` in `callDeps()` header.
- Overlay hide-gate no longer requires `phase === "ready"` when user bypassed.

## Testing
- `node --test test/*.test.mjs` -> **244 / 244 pass**
- Extension boots cleanly on all live canvases
- Diagnose round-trip verified end-to-end

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
