### PR TITLE
Consume deterministic lookupId to simplify wizard provider resolution

### DIFF
--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/artifact-cli.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/artifact-cli.test.mjs
@@ -4,7 +4,7 @@ import {
     buildCompositionFromCli,
 } from "../composition/artifact-cli.mjs";
 import { computePipelineFastPath } from "../composition/pipeline-fast-path.mjs";
-import { parseLookupId, findLayerByLookupId } from "../ui/lookup-id.mjs";
+import { findLayerByLookupId } from "../ui/lookup-id.mjs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -157,7 +157,6 @@ describe("buildCompositionFromCli", () => {
                 assert.equal(a.stack[0].sourceId, null);
                 assert.equal(a.stack[0].presetId, null);
                 assert.equal(a.stack[0].lookupId, null);
-                assert.equal(parseLookupId(a.stack[0].lookupId), null);
                 assert.equal(a.stack[0].manifestPath, null);
             }
 
@@ -195,13 +194,10 @@ describe("buildCompositionFromCli", () => {
             assert.equal(winner.hidden, false);
             assert.equal(winner.manifestPath, ".specify/presets/compliance/preset.yml");
             assert.equal(winner.lookupId, "preset:compliance:command:speckit.plan");
-            // Behavioral coverage: lookupId parses to the expected shape and
-            // round-trips through findLayerByLookupId back to this winner.
-            const parsed = parseLookupId(winner.lookupId);
-            assert.equal(parsed.providerKind, "preset");
-            assert.equal(parsed.providerId, "compliance");
-            assert.equal(parsed.kind, "command");
-            assert.equal(parsed.name, "speckit.plan");
+            // Behavioral coverage: the CLI-shaped composition artifact
+            // round-trips through findLayerByLookupId back to this winner
+            // (parseLookupId's own shape/edge-case behavior is covered by
+            // test/lookup-id.test.mjs — no need to re-assert it here).
             assert.equal(findLayerByLookupId(cmd, winner.lookupId), winner);
 
             // Hidden built-in layer.

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/artifact-cli.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/artifact-cli.test.mjs
@@ -4,6 +4,7 @@ import {
     buildCompositionFromCli,
 } from "../composition/artifact-cli.mjs";
 import { computePipelineFastPath } from "../composition/pipeline-fast-path.mjs";
+import { parseLookupId, findLayerByLookupId } from "../ui/lookup-id.mjs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -156,6 +157,7 @@ describe("buildCompositionFromCli", () => {
                 assert.equal(a.stack[0].sourceId, null);
                 assert.equal(a.stack[0].presetId, null);
                 assert.equal(a.stack[0].lookupId, null);
+                assert.equal(parseLookupId(a.stack[0].lookupId), null);
                 assert.equal(a.stack[0].manifestPath, null);
             }
 
@@ -193,6 +195,14 @@ describe("buildCompositionFromCli", () => {
             assert.equal(winner.hidden, false);
             assert.equal(winner.manifestPath, ".specify/presets/compliance/preset.yml");
             assert.equal(winner.lookupId, "preset:compliance:command:speckit.plan");
+            // Behavioral coverage: lookupId parses to the expected shape and
+            // round-trips through findLayerByLookupId back to this winner.
+            const parsed = parseLookupId(winner.lookupId);
+            assert.equal(parsed.providerKind, "preset");
+            assert.equal(parsed.providerId, "compliance");
+            assert.equal(parsed.kind, "command");
+            assert.equal(parsed.name, "speckit.plan");
+            assert.equal(findLayerByLookupId(cmd, winner.lookupId), winner);
 
             // Hidden built-in layer.
             const built = cmd.stack[1];

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/compute-provider-contributions.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/compute-provider-contributions.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { computeProviderContributions } from "../ui/composition.js";
+
+// computeProviderContributions buckets stack layers by provider id, tallying
+// "customized" (core-inventory overrides) vs "added" (new) contributions.
+// Bucket key resolution: prefer parseLookupId(layer.lookupId)?.providerId,
+// falling back to layer.presetId ?? layer.extensionId for wizard-synthesized
+// hook layers (which carry lookupId: null).
+
+describe("computeProviderContributions", () => {
+    test("buckets a preset winner by lookupId providerId", () => {
+        const artifacts = [
+            {
+                id: "commands/speckit.plan",
+                kind: "command",
+                stack: [
+                    { layer: "preset", presetId: "compliance", lookupId: "preset:compliance:command:speckit.plan" },
+                ],
+            },
+        ];
+        const contributions = computeProviderContributions(artifacts);
+        assert.ok(contributions.has("compliance"));
+    });
+
+    test("buckets an extension layer by lookupId providerId", () => {
+        const artifacts = [
+            {
+                id: "templates/spec.md",
+                kind: "template",
+                stack: [
+                    { layer: "extension", extensionId: "foo", lookupId: "extension:foo:template:spec.md" },
+                ],
+            },
+        ];
+        const contributions = computeProviderContributions(artifacts);
+        assert.ok(contributions.has("foo"));
+    });
+
+    test("falls back to extensionId for hook-synthetic layers with lookupId: null", () => {
+        const artifacts = [
+            {
+                id: "commands/some-hook-command",
+                kind: "hook",
+                hookBindings: [{ phase: "after_specify" }],
+                stack: [
+                    { layer: "extension", extensionId: "hooks-ext", lookupId: null },
+                ],
+            },
+        ];
+        const contributions = computeProviderContributions(artifacts);
+        assert.ok(contributions.has("hooks-ext"));
+    });
+
+    test("lookupId wins when both lookupId and legacy presetId/extensionId are present", () => {
+        const artifacts = [
+            {
+                id: "commands/speckit.plan",
+                kind: "command",
+                stack: [
+                    {
+                        layer: "preset",
+                        presetId: "legacy-id",
+                        extensionId: "legacy-ext-id",
+                        lookupId: "preset:compliance:command:speckit.plan",
+                    },
+                ],
+            },
+        ];
+        const contributions = computeProviderContributions(artifacts);
+        assert.ok(contributions.has("compliance"));
+        assert.ok(!contributions.has("legacy-id"));
+        assert.ok(!contributions.has("legacy-ext-id"));
+    });
+});

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/lookup-id.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/lookup-id.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { parseLookupId, findLayerByLookupId } from "../ui/lookup-id.mjs";
+
+describe("parseLookupId", () => {
+    test("parses a preset command lookupId", () => {
+        assert.deepEqual(
+            parseLookupId("preset:compliance:command:speckit.plan"),
+            { providerKind: "preset", providerId: "compliance", kind: "command", name: "speckit.plan" },
+        );
+    });
+
+    test("parses an extension template lookupId", () => {
+        assert.deepEqual(
+            parseLookupId("extension:foo:template:spec.md"),
+            { providerKind: "extension", providerId: "foo", kind: "template", name: "spec.md" },
+        );
+    });
+
+    test("treats colons in <name> as opaque tail", () => {
+        const parsed = parseLookupId("preset:x:command:has:colons:in:name");
+        assert.equal(parsed.name, "has:colons:in:name");
+        assert.equal(parsed.providerId, "x");
+        assert.equal(parsed.kind, "command");
+    });
+
+    test("returns null for null/empty/garbage/unknown-provider-kind input", () => {
+        assert.equal(parseLookupId(null), null);
+        assert.equal(parseLookupId(""), null);
+        assert.equal(parseLookupId("garbage"), null);
+        assert.equal(parseLookupId("core:x:y:z"), null);
+        assert.equal(parseLookupId(undefined), null);
+        assert.equal(parseLookupId("preset:x:y"), null);
+    });
+});
+
+describe("findLayerByLookupId", () => {
+    const artifact = {
+        id: "commands/speckit.plan",
+        stack: [
+            { lookupId: "preset:compliance:command:speckit.plan", active: true },
+            { lookupId: null, active: false },
+        ],
+    };
+
+    test("returns the matching layer", () => {
+        const layer = findLayerByLookupId(artifact, "preset:compliance:command:speckit.plan");
+        assert.equal(layer, artifact.stack[0]);
+    });
+
+    test("returns null when lookupId is null", () => {
+        assert.equal(findLayerByLookupId(artifact, null), null);
+    });
+
+    test("returns null when no layer matches", () => {
+        assert.equal(findLayerByLookupId(artifact, "preset:other:command:x"), null);
+    });
+
+    test("returns null when compArtifact is null", () => {
+        assert.equal(findLayerByLookupId(null, "preset:compliance:command:speckit.plan"), null);
+    });
+});

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/phase-runtime-command-source-path.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/phase-runtime-command-source-path.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, test, beforeEach } from "node:test";
+import { commandSourcePath } from "../ui/phase-runtime.js";
+import { state } from "../ui/state.js";
+
+// commandSourcePath resolves the on-disk markdown path for a command tile.
+// Priority: (1) composition activeLayer.sourcePath, (2) derived preset path
+// from the winning layer's `lookupId` provider id + `p.commandName`.
+
+describe("commandSourcePath", () => {
+    beforeEach(() => {
+        state.snapshot = null;
+    });
+
+    test("returns null for falsy input", () => {
+        assert.equal(commandSourcePath(null), null);
+    });
+
+    test("prefers composition activeLayer.sourcePath when present", () => {
+        state.snapshot = {
+            composition: {
+                artifacts: [
+                    {
+                        id: "commands/speckit.plan",
+                        stack: [
+                            {
+                                active: true,
+                                sourcePath: ".specify/presets/compliance/commands/speckit.plan.md",
+                                lookupId: "preset:compliance:command:speckit.plan",
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+        const p = { id: "plan", commandName: "speckit.plan", lookupId: "preset:compliance:command:speckit.plan" };
+        assert.equal(commandSourcePath(p), ".specify/presets/compliance/commands/speckit.plan.md");
+    });
+
+    test("falls back to deriving path from active composition layer's lookupId when sourcePath is absent", () => {
+        state.snapshot = {
+            composition: {
+                artifacts: [
+                    {
+                        id: "commands/speckit.plan",
+                        stack: [
+                            {
+                                active: true,
+                                sourcePath: null,
+                                lookupId: "preset:compliance:command:speckit.plan",
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+        const p = { id: "plan", commandName: "speckit.plan", lookupId: null };
+        assert.equal(commandSourcePath(p), ".specify/presets/compliance/commands/speckit.plan.md");
+    });
+
+    test("falls back to the phase's own lookupId when there is no composition entry", () => {
+        state.snapshot = { composition: { artifacts: [] } };
+        const p = { id: "plan", commandName: "speckit.plan", lookupId: "preset:game-narrative:command:speckit.plan" };
+        assert.equal(commandSourcePath(p), ".specify/presets/game-narrative/commands/speckit.plan.md");
+    });
+
+    test("returns null for an extension-provided lookupId (not a preset path)", () => {
+        state.snapshot = { composition: { artifacts: [] } };
+        const p = { id: "foo", commandName: "speckit.foo.bar", lookupId: "extension:foo:command:speckit.foo.bar" };
+        assert.equal(commandSourcePath(p), null);
+    });
+
+    test("returns null when there is no lookupId and no composition entry", () => {
+        state.snapshot = { composition: { artifacts: [] } };
+        const p = { id: "specify", commandName: "speckit.specify", lookupId: null };
+        assert.equal(commandSourcePath(p), null);
+    });
+});

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/phase-runtime-command-source-path.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/phase-runtime-command-source-path.test.mjs
@@ -5,7 +5,11 @@ import { state } from "../ui/state.js";
 
 // commandSourcePath resolves the on-disk markdown path for a command tile.
 // Priority: (1) composition activeLayer.sourcePath, (2) derived preset path
-// from the winning layer's `lookupId` provider id + `p.commandName`.
+// from the winning layer's `lookupId` provider id + `p.commandName`,
+// (3) legacy `p.source: "preset:<id>"` string fallback — this is the ONLY
+// provenance the real snapshot-builder.mjs::buildCommands producer attaches
+// to preset-only command objects today (no `lookupId` yet), so this
+// fallback must stay reachable until that producer is migrated.
 
 describe("commandSourcePath", () => {
     beforeEach(() => {
@@ -70,7 +74,16 @@ describe("commandSourcePath", () => {
         assert.equal(commandSourcePath(p), null);
     });
 
-    test("returns null when there is no lookupId and no composition entry", () => {
+    test("falls back to legacy p.source string when there is no lookupId at all (real preset-only command shape)", () => {
+        // Mirrors what snapshot-builder.mjs::buildCommands actually emits for
+        // a preset-only command: `source: "preset:<presetId>"`, no
+        // `lookupId`, and no composition artifact entry.
+        state.snapshot = { composition: { artifacts: [] } };
+        const p = { id: "plan", commandName: "speckit.plan", source: "preset:compliance" };
+        assert.equal(commandSourcePath(p), ".specify/presets/compliance/commands/speckit.plan.md");
+    });
+
+    test("returns null when there is no lookupId, no legacy source, and no composition entry", () => {
         state.snapshot = { composition: { artifacts: [] } };
         const p = { id: "specify", commandName: "speckit.specify", lookupId: null };
         assert.equal(commandSourcePath(p), null);

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/server-integration.test.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/test/server-integration.test.mjs
@@ -739,6 +739,56 @@ test("S6: .specify/presets/.registry order flows through preset-loader into scan
     }
 });
 
+// -------- S6b: scanner → buildStateSnapshot → commandSourcePath -----------
+
+test("S6b: a real scanned preset command's snapshot object resolves via commandSourcePath's legacy source fallback", async () => {
+    // Regression test: buildCommands forwards `cmd.source` ("preset:<id>")
+    // onto snapshot.commands but does not attach a `lookupId` — that field
+    // only exists on composition-artifact stack layers, a separate producer.
+    // commandSourcePath must still resolve a path for these real command
+    // objects, not silently return null.
+    const ws = tmpWs();
+    try {
+        mkdirSync(join(ws, ".specify", "presets", "alpha", "commands"), { recursive: true });
+        writeFileSync(
+            join(ws, ".specify", "presets", ".registry"),
+            JSON.stringify([{ id: "alpha", priority: 100, enabled: true }]),
+        );
+        writeFileSync(
+            join(ws, ".specify", "presets", "alpha", "preset.yml"),
+            [
+                "preset:",
+                "  name: Alpha",
+                "  version: 1.0.0",
+                "provides:",
+                "  templates:",
+                "    - type: command",
+                "      name: speckit.a1",
+                "      file: commands/a1.md",
+                "",
+            ].join("\n"),
+        );
+        writeFileSync(
+            join(ws, ".specify", "presets", "alpha", "commands", "a1.md"),
+            "---\nhandoffs: []\n---\n# A1\n",
+        );
+
+        const scan = await scanWorkspace(ws, await realFsDeps());
+        const snap = buildStateSnapshot(scan);
+        const cmd = (snap.commands ?? []).find((c) => c.commandName === "speckit.a1" || c.name === "speckit.a1");
+        assert.ok(cmd, `snapshot.commands missing speckit.a1: ${JSON.stringify(snap.commands)}`);
+        assert.equal(cmd.source, "preset:alpha");
+        assert.equal(cmd.lookupId, undefined, "buildCommands does not attach lookupId today");
+
+        const { commandSourcePath } = await import("../ui/phase-runtime.js");
+        const { state } = await import("../ui/state.js");
+        state.snapshot = { composition: { artifacts: [] } };
+        assert.equal(commandSourcePath(cmd), ".specify/presets/alpha/commands/speckit.a1.md");
+    } finally {
+        rmSync(ws, { recursive: true, force: true });
+    }
+});
+
 // -------- S7: scanner → buildStateSnapshot lock/gate ----------------------
 
 test("S7: buildStateSnapshot derives per-phase locked from durable setup completion", async () => {

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/composition.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/composition.js
@@ -172,16 +172,7 @@ export function computeProviderContributions(artifacts) {
             if (layer.layer !== "preset" && layer.layer !== "extension") continue;
             // Prefer the deterministic lookupId's providerId; fall back to
             // legacy presetId/extensionId for wizard-synthesized hook layers
-            // (applyHookAttributions writes lookupId: null — see
-            // composition/artifact-cli.mjs). This fallback can be deleted
-            // once spec-kit issue #4343 ("Expose hook contributions and
-            // runtime bindings via specify artifact") lands AND the wizard
-            // migrates off applyHookAttributions to consume CLI-native hook
-            // artifacts directly (tracked alongside #4209) — at that point
-            // every hook layer will carry a real, non-null lookupId and this
-            // fallback becomes dead code. Landing #4343 alone is not
-            // sufficient; applyHookAttributions must stop synthesizing
-            // lookupId: null first.
+            // (applyHookAttributions writes lookupId: null).
             const id = parseLookupId(layer.lookupId)?.providerId
                 ?? layer.presetId
                 ?? layer.extensionId;

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/composition.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/composition.js
@@ -172,7 +172,16 @@ export function computeProviderContributions(artifacts) {
             if (layer.layer !== "preset" && layer.layer !== "extension") continue;
             // Prefer the deterministic lookupId's providerId; fall back to
             // legacy presetId/extensionId for wizard-synthesized hook layers
-            // (applyHookAttributions writes lookupId: null).
+            // (applyHookAttributions writes lookupId: null — see
+            // composition/artifact-cli.mjs). This fallback can be deleted
+            // once spec-kit issue #4343 ("Expose hook contributions and
+            // runtime bindings via specify artifact") lands AND the wizard
+            // migrates off applyHookAttributions to consume CLI-native hook
+            // artifacts directly (tracked alongside #4209) — at that point
+            // every hook layer will carry a real, non-null lookupId and this
+            // fallback becomes dead code. Landing #4343 alone is not
+            // sufficient; applyHookAttributions must stop synthesizing
+            // lookupId: null first.
             const id = parseLookupId(layer.lookupId)?.providerId
                 ?? layer.presetId
                 ?? layer.extensionId;

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/composition.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/composition.js
@@ -13,6 +13,7 @@ import {
     renderCompositionArtifacts,
     setArtifactRowsDeps,
 } from "./composition-artifacts.js";
+import { parseLookupId } from "./lookup-id.mjs";
 
 // -------- Section: composition/layers.mjs --------
 // Single source of truth for the composition layer-stack order.
@@ -169,10 +170,12 @@ export function computeProviderContributions(artifacts) {
         const seen = new Set();
         for (const layer of a.stack ?? []) {
             if (layer.layer !== "preset" && layer.layer !== "extension") continue;
-            const id = layer.presetId
-                || layer.extensionId
-                || layer.presetName
-                || layer.extensionName;
+            // Prefer the deterministic lookupId's providerId; fall back to
+            // legacy presetId/extensionId for wizard-synthesized hook layers
+            // (applyHookAttributions writes lookupId: null).
+            const id = parseLookupId(layer.lookupId)?.providerId
+                ?? layer.presetId
+                ?? layer.extensionId;
             if (!id || seen.has(id)) continue;
             seen.add(id);
             let bucket = out.get(id);

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/lookup-id.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/lookup-id.mjs
@@ -1,0 +1,34 @@
+// Pure helpers for the deterministic `lookupId` field carried on composition
+// stack layers (spec-kit CLI issue #4210 / PR #4305).
+//
+// Format: `preset:<presetId>:<kind>:<name>` or `extension:<extId>:<kind>:<name>`,
+// `null` for core (built-in) layers. Stable across reinstalls; NOT a CLI
+// round-trip key (do not send it back to `specify` commands).
+
+const KNOWN_PROVIDER_KINDS = new Set(["preset", "extension"]);
+
+// Parse a `lookupId` string into its constituent parts. Returns `null` for
+// anything that isn't a recognized `preset:`/`extension:` lookupId (including
+// `null`, empty string, garbage, or an unknown provider kind like `core:...`).
+//
+// Colons inside `<name>` are legal — everything after the third colon is
+// treated as the opaque `name` tail (locked decision: do not split further).
+export function parseLookupId(lookupId) {
+    if (typeof lookupId !== "string" || lookupId.length === 0) return null;
+    const parts = lookupId.split(":");
+    if (parts.length < 4) return null;
+    const [providerKind, providerId, kind, ...nameParts] = parts;
+    if (!KNOWN_PROVIDER_KINDS.has(providerKind)) return null;
+    if (!providerId || !kind) return null;
+    const name = nameParts.join(":");
+    if (!name) return null;
+    return { providerKind, providerId, kind, name };
+}
+
+// Find the stack layer within a composition artifact whose `lookupId`
+// matches. Returns `null` when `lookupId` is falsy or no layer matches.
+export function findLayerByLookupId(compArtifact, lookupId) {
+    if (!lookupId || !compArtifact) return null;
+    const stack = compArtifact.stack ?? [];
+    return stack.find((layer) => layer?.lookupId === lookupId) ?? null;
+}

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/lookup-id.mjs
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/lookup-id.mjs
@@ -1,5 +1,5 @@
 // Pure helpers for the deterministic `lookupId` field carried on composition
-// stack layers (spec-kit CLI issue #4210 / PR #4305).
+// stack layers.
 //
 // Format: `preset:<presetId>:<kind>:<name>` or `extension:<extId>:<kind>:<name>`,
 // `null` for core (built-in) layers. Stable across reinstalls; NOT a CLI

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-card.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-card.js
@@ -329,6 +329,7 @@ export function synthesizeCanonicalPhase(id) {
         optional: isCanonicalOptional(id),
         locked: false,
         source: "core",
+        lookupId: null,
         artifact: null,
         artifactPath: null,
     };

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
@@ -941,9 +941,4 @@ export function lookupLayerByLookupId(lookupId) {
     return null;
 }
 
-// Deprecated: use `lookupActiveLayerForCommand({ id, commandName })` instead.
-// Kept as a thin wrapper for one commit while callers migrate.
-export function lookupActiveLayer(id, commandName) {
-    return lookupActiveLayerForCommand({ id, commandName });
-}
 

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
@@ -896,6 +896,11 @@ export function renderMoreCommandsPanel() {
 // Priority:
 //   1. composition activeLayer.sourcePath (accurate — includes preset overrides).
 //   2. derived preset path from the `lookupId` provider id + `p.commandName`.
+//   3. derived preset path from the legacy `p.source` string ("preset:<id>") —
+//      still the ONLY provenance snapshot-builder.mjs::buildCommands attaches
+//      to preset-only command objects (it forwards `cmd.source` but not a
+//      `lookupId`; the composition-artifact lookupId pipeline is a separate
+//      producer). Keep this until that producer starts propagating lookupId.
 // Returns null when the file isn't on disk (e.g. synthesized core-only commands).
 export function commandSourcePath(p) {
     if (!p) return null;
@@ -911,6 +916,12 @@ export function commandSourcePath(p) {
         : null;
     if (parsed && p.commandName) {
         return `.specify/presets/${parsed.providerId}/commands/${p.commandName}.md`;
+    }
+    // Legacy fallback: derive from `source: "preset:<presetId>"` for
+    // preset-only commands that don't yet carry a `lookupId` at all.
+    if (typeof p.source === "string" && p.source.startsWith("preset:") && p.commandName) {
+        const presetId = p.source.slice("preset:".length).split(":")[0];
+        return `.specify/presets/${presetId}/commands/${p.commandName}.md`;
     }
     return null;
 }

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
@@ -199,6 +199,7 @@ export function resolvePipelineEntry(id, snapshot) {
         // (state.json has status:"done", artifactPath set). Mirrors the
         // extension branch below.
         const scanned = snapshot?.phases?.[id] ?? null;
+        const active = lookupActiveLayerForCommand({ id, commandName: `speckit.${id}` });
         return {
             kind: "core",
             id,
@@ -218,6 +219,7 @@ export function resolvePipelineEntry(id, snapshot) {
                 commandName: `speckit.${id}`,
                 artifactPath: scanned?.artifactPath ?? null,
                 lastRunAt: scanned?.lastRunAt ?? null,
+                lookupId: active?.lookupId ?? null,
                 ...(scanned?.folderPath ? { folderPath: scanned.folderPath } : {}),
             },
         };
@@ -235,6 +237,7 @@ export function resolvePipelineEntry(id, snapshot) {
         // there so the phase card renders a live "Writes to" link the same
         // way core phases do.
         const scanned = snapshot?.phases?.[id] ?? null;
+        const active = lookupActiveLayerForCommand({ id, commandName: extResolved.commandName });
         return {
             kind: "extension",
             id,
@@ -251,6 +254,7 @@ export function resolvePipelineEntry(id, snapshot) {
                 source: `extension:${extResolved.ext.id}`,
                 artifactPath: scanned?.artifactPath ?? null,
                 lastRunAt: scanned?.lastRunAt ?? null,
+                lookupId: active?.lookupId ?? null,
                 // LLM-inferred metadata from artifact-targets.json cache
                 // (via extension.inferArtifactTargets prompt). The phase
                 // card reads these to render the tagline under the header

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
@@ -22,6 +22,7 @@ import {
 import { CANONICAL_BY_FULL } from "../pipeline/effective-phases.mjs";
 import { resolveHooksForCommand } from "../pipeline/active-artifacts.mjs";
 import { effectivePipelinePhases } from "../pipeline/effective-phases.mjs";
+import { findLayerByLookupId } from "./lookup-id.mjs";
 
 // -------- Section: phase/clarifications.js --------
 
@@ -894,7 +895,7 @@ export function renderMoreCommandsPanel() {
 // Returns null when the file isn't on disk (e.g. synthesized core-only commands).
 export function commandSourcePath(p) {
     if (!p) return null;
-    const activeLayer = lookupActiveLayer(p.id, p.commandName);
+    const activeLayer = lookupActiveLayerForCommand(p);
     if (activeLayer?.sourcePath) return activeLayer.sourcePath;
     // Derive from `source: "preset:<presetId>"` for preset-only commands
     // that don't have composition entries (game-narrative extras).
@@ -905,13 +906,35 @@ export function commandSourcePath(p) {
     return null;
 }
 
-// Look up the winning composition layer for a command id (either "commands/<name>" or a phase id).
-export function lookupActiveLayer(id, commandName) {
+// Look up the winning composition layer for a phase, using phase-discovery
+// semantics: prefer the "commands/<commandName>" artifact, falling back to
+// the phase `id` (either "commands/<name>" or a bare phase id).
+export function lookupActiveLayerForCommand(p) {
+    const id = p?.id;
+    const commandName = p?.commandName;
     const compArtifacts = state.snapshot?.composition?.artifacts ?? [];
     const cmdLookupId = commandName ? `commands/${commandName}` : null;
     const compArtifact =
         (cmdLookupId && compArtifacts.find((a) => a.id === cmdLookupId)) ||
         compArtifacts.find((a) => a.id === id);
     return (compArtifact?.stack ?? []).find((l) => l.active) || null;
+}
+
+// Look up a composition stack layer by its deterministic `lookupId`
+// (see ui/lookup-id.mjs). Returns `null` when no artifact/layer matches.
+export function lookupLayerByLookupId(lookupId) {
+    if (!lookupId) return null;
+    const compArtifacts = state.snapshot?.composition?.artifacts ?? [];
+    for (const compArtifact of compArtifacts) {
+        const layer = findLayerByLookupId(compArtifact, lookupId);
+        if (layer) return layer;
+    }
+    return null;
+}
+
+// Deprecated: use `lookupActiveLayerForCommand({ id, commandName })` instead.
+// Kept as a thin wrapper for one commit while callers migrate.
+export function lookupActiveLayer(id, commandName) {
+    return lookupActiveLayerForCommand({ id, commandName });
 }
 

--- a/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
+++ b/plugins/spec-kit-copilot-wizard/extensions/speckit-wizard-canvas/ui/phase-runtime.js
@@ -22,7 +22,7 @@ import {
 import { CANONICAL_BY_FULL } from "../pipeline/effective-phases.mjs";
 import { resolveHooksForCommand } from "../pipeline/active-artifacts.mjs";
 import { effectivePipelinePhases } from "../pipeline/effective-phases.mjs";
-import { findLayerByLookupId } from "./lookup-id.mjs";
+import { findLayerByLookupId, parseLookupId } from "./lookup-id.mjs";
 
 // -------- Section: phase/clarifications.js --------
 
@@ -895,17 +895,22 @@ export function renderMoreCommandsPanel() {
 // Resolve the on-disk markdown path for a command tile, when known.
 // Priority:
 //   1. composition activeLayer.sourcePath (accurate — includes preset overrides).
-//   2. derived preset path from `p.source` + `p.commandName`.
+//   2. derived preset path from the `lookupId` provider id + `p.commandName`.
 // Returns null when the file isn't on disk (e.g. synthesized core-only commands).
 export function commandSourcePath(p) {
     if (!p) return null;
     const activeLayer = lookupActiveLayerForCommand(p);
     if (activeLayer?.sourcePath) return activeLayer.sourcePath;
-    // Derive from `source: "preset:<presetId>"` for preset-only commands
-    // that don't have composition entries (game-narrative extras).
-    if (typeof p.source === "string" && p.source.startsWith("preset:") && p.commandName) {
-        const presetId = p.source.slice("preset:".length).split(":")[0];
-        return `.specify/presets/${presetId}/commands/${p.commandName}.md`;
+    // Derive from the preset provider id for preset-only commands that
+    // don't have composition entries (game-narrative extras). Prefer the
+    // active composition layer's lookupId, falling back to the phase's own.
+    const parsedActive = parseLookupId(activeLayer?.lookupId);
+    const parsedPhase = parseLookupId(p.lookupId);
+    const parsed = parsedActive?.providerKind === "preset" ? parsedActive
+        : parsedPhase?.providerKind === "preset" ? parsedPhase
+        : null;
+    if (parsed && p.commandName) {
+        return `.specify/presets/${parsed.providerId}/commands/${p.commandName}.md`;
     }
     return null;
 }


### PR DESCRIPTION
## Summary

Consumes the deterministic `lookupId` field carried on composition stack layers (`preset:<presetId>:<kind>:<name>` / `extension:<extId>:<kind>:<name>` / `null` for core) to replace ad-hoc string-parsing and multi-field OR fallbacks across the wizard with a single, well-tested parsing path.

Stacked on this repo's wizard composition/artifact-cli PR — base ref is intentionally that branch, not `main`.

## Changes (in migration order, each commit independently green)

1. **New** `ui/lookup-id.mjs` — pure `parseLookupId(str)` and `findLayerByLookupId(compArtifact, lookupId)` helpers.
2. **Split** `lookupActiveLayer` into `lookupActiveLayerForCommand(p)` and `lookupLayerByLookupId(lookupId)`; migrated `commandSourcePath` to the new name.
3. **Attached** `lookupId` additively to phase objects at all phase-construction sites (core branch, extension branch, `synthesizeCanonicalPhase`).
4. **Switched** `commandSourcePath`'s preset-path derivation from string-parsing `p.source` to `parseLookupId`-based provider extraction (still preset-kind-only, matching prior behavior).
5. **Switched** `computeProviderContributions`'s 4-way OR (`presetId || extensionId || presetName || extensionName`) to `parseLookupId(layer.lookupId)?.providerId`, falling back to `presetId ?? extensionId` for wizard-synthesized hook layers (which intentionally carry `lookupId: null`).
6. **Upgraded** the two pass-through equality asserts in `test/artifact-cli.test.mjs` to behavioral coverage.
7. **Dropped** the one-commit `lookupActiveLayer` deprecation shim once its single caller was migrated.

## Out of scope (deliberately, tracked separately)

- Removing the `.specify/presets/<presetId>/commands/<commandName>.md` filesystem-path construction in `commandSourcePath`.
- Rewriting `accumulateProvidesCounts` / `summarizeInstalled`.
- Deleting `applyHookAttributions`, or synthesizing hook `lookupId`s client-side — hook layers keep `lookupId: null` and rely on the `presetId ?? extensionId` fallback until the CLI exposes hook artifacts with real lookupIds and the wizard migrates off `applyHookAttributions` entirely.
- Dropping `presetName` / `extensionName` display fallbacks.
- Dropping the legacy `p.source` field globally (kept as additive-legacy).

## Testing

- `npm test` — 225/225 passing.
- New test files: `test/lookup-id.test.mjs`, `test/phase-runtime-command-source-path.test.mjs`, `test/compute-provider-contributions.test.mjs`, plus behavioral upgrades in `test/artifact-cli.test.mjs`. Each test targets a distinct code branch (reviewed for redundancy, one duplicate trimmed).