### PR TITLE
Add README showcase videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Copilot experience around it.
 > [*Spec Kit Wizard: Visual Spec-Driven Development with GitHub Copilot*](https://youtu.be/-yRdys89DtY?si=0XbgF8zy2Z6rBdgq)
 > showcases a guided visual workflow for exploring, understanding, and running the
 > full Spec-Driven Development lifecycle, plus discovering and applying
-> customizations that tailor the workflow to your team.
+> customizations that tailor the workflow to your project.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Copilot experience around it.
 
 **Status:** active development.
 
+> [!NOTE]
+> **New Copilot canvas showcase videos**
+>
+> See how GitHub Copilot App's canvas functionality turns Spec Kit workflows into
+> visual, Copilot-interactive experiences:
+> [*Spec Kit Assess: Visual Idea Intake with GitHub Copilot*](https://youtu.be/eo1_QUZMYb0?si=dCjcCYXzWjpLPfKC)
+> showcases the `assess` extension's five-stage discovery funnel — intake,
+> research, define, shape, and decide — helping teams turn rough concepts into a
+> clear go, needs clarification, or kill decision before moving into SDD.
+>
+> [*Spec Kit Wizard: Visual Spec-Driven Development with GitHub Copilot*](https://youtu.be/-yRdys89DtY?si=0XbgF8zy2Z6rBdgq)
+> showcases a guided visual workflow for exploring, understanding, and running the
+> full Spec-Driven Development lifecycle, plus discovering and applying
+> customizations that tailor the workflow to your team, on top of Spec Kit's
+> `specify` CLI.
+
 ## Background
 
 [Spec Kit](https://github.com/github/spec-kit) provides the `specify` CLI and

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copilot experience around it.
 **Status:** active development.
 
 > [!NOTE]
-> **New Copilot canvas showcase videos**
+> **See GitHub Copilot App canvases in action**
 >
 > See how GitHub Copilot App's canvas functionality turns Spec Kit workflows into
 > visual, Copilot-interactive experiences:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copilot experience around it.
 **Status:** active development.
 
 > [!NOTE]
-> **Explore Spec Kit workflows visually with GitHub Copilot**
+> **Experience visual, Copilot-interactive Spec Kit canvases**
 >
 > See how GitHub Copilot App's canvas functionality turns Spec Kit workflows into
 > visual, Copilot-interactive experiences:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Copilot experience around it.
 > [*Spec Kit Wizard: Visual Spec-Driven Development with GitHub Copilot*](https://youtu.be/-yRdys89DtY?si=0XbgF8zy2Z6rBdgq)
 > showcases a guided visual workflow for exploring, understanding, and running the
 > full Spec-Driven Development lifecycle, plus discovering and applying
-> customizations that tailor the workflow to your team, on top of Spec Kit's
-> `specify` CLI.
+> customizations that tailor the workflow to your team.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copilot experience around it.
 **Status:** active development.
 
 > [!NOTE]
-> **See GitHub Copilot App canvases in action**
+> **Explore Spec Kit workflows visually with GitHub Copilot**
 >
 > See how GitHub Copilot App's canvas functionality turns Spec Kit workflows into
 > visual, Copilot-interactive experiences:


### PR DESCRIPTION
## Summary
- Add a top-of-README note showcasing the new GitHub Copilot App canvas videos
- Link the Spec Kit Assess video first, followed by the Spec Kit Wizard video
- Describe Assess as a five-stage idea discovery funnel and Wizard as a visual SDD workflow with customization support

## Testing
- Not run (documentation-only change)