### PR TITLE
fix(sdd): ignore fenced Markdown examples

### DIFF
--- a/plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/sdd.mjs
+++ b/plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/sdd.mjs
@@ -252,18 +252,35 @@ function constitutionStatus(text) {
     return placeholders > 0 ? "template" : "ratified";
 }
 
+function advanceMarkdownFence(line, openFence) {
+    const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (!match) return { openFence, isFenceLine: false };
+
+    const marker = match[1][0];
+    const length = match[1].length;
+    const rest = match[2];
+    if (!openFence) {
+        if (marker === "`" && rest.includes("`")) {
+            return { openFence: null, isFenceLine: false };
+        }
+        return { openFence: { marker, length }, isFenceLine: true };
+    }
+    if (marker === openFence.marker && length >= openFence.length && !rest.trim()) {
+        return { openFence: null, isFenceLine: true };
+    }
+    return { openFence, isFenceLine: false };
+}
+
 // Count task checkboxes in tasks.md to derive implementation progress.
-function taskProgress(text) {
+export function taskProgress(text) {
     if (typeof text !== "string") return { total: 0, completed: 0 };
     let total = 0;
     let completed = 0;
-    let inFence = false;
+    let openFence = null;
     for (const line of text.split(/\r?\n/)) {
-        if (line.startsWith("```")) {
-            inFence = !inFence;
-            continue;
-        }
-        if (inFence) continue;
+        const fenceState = advanceMarkdownFence(line, openFence);
+        openFence = fenceState.openFence;
+        if (fenceState.isFenceLine || openFence) continue;
         const m = line.match(/^\s*[-*+]\s+\[([ xX])\]/);
         if (!m) continue;
         total++;
@@ -519,13 +536,11 @@ export function readArtifact(projectRoot, featureInput, stageKey) {
 export function extractClarifications(text) {
     const clarifications = [];
     let section = "";
-    let inCodeFence = false;
+    let openFence = null;
     for (const line of String(text || "").split(/\r?\n/)) {
-        if (line.startsWith("```")) {
-            inCodeFence = !inCodeFence;
-            continue;
-        }
-        if (inCodeFence) continue;
+        const fenceState = advanceMarkdownFence(line, openFence);
+        openFence = fenceState.openFence;
+        if (fenceState.isFenceLine || openFence) continue;
         const heading = line.match(/^#{1,6}\s+(.+?)\s*$/);
         if (heading) {
             section = heading[1].trim();

--- a/plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/tests/sdd.test.mjs
+++ b/plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/tests/sdd.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { extractClarifications, scanFeatures } from "../sdd.mjs";
+import { extractClarifications, scanFeatures, taskProgress } from "../sdd.mjs";
 
 function write(path, content, mtimeSeconds) {
     writeFileSync(path, content);
@@ -40,6 +40,30 @@ test("implementation progress scans the complete bounded tasks artifact", (t) =>
         completed: 1,
     });
     assert.equal(feature.nextStage, "implement");
+});
+
+test("task counting ignores fenced examples but keeps indented list items", () => {
+    // A fence hides its contents whether the marker is plain, tilde, or indented
+    // up to the three spaces CommonMark allows.
+    assert.deepEqual(taskProgress([
+        "- [x] T001 Real",
+        "```markdown",
+        "- [x] T900 Example in a backtick fence",
+        "```",
+        "   ~~~markdown",
+        "- [x] T901 Example in an indented tilde fence",
+        "   ~~~",
+        "- [ ] T002 Real",
+    ].join("\n")), { total: 2, completed: 1 });
+
+    // An indented checkbox is a nested list item, so it counts. Markdown also lets
+    // four spaces open a code block, and telling the two apart needs the block
+    // context a full CommonMark parser tracks. Counting is the safe side of that
+    // ambiguity: an extra task is visible in the dashboard, a dropped one is not.
+    assert.deepEqual(taskProgress([
+        "- [ ] T001 Parent",
+        "    - [x] T002 Nested child",
+    ].join("\n")), { total: 2, completed: 1 });
 });
 
 test("clarifications retain stable indices across supported markdown blocks", () => {

--- a/plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/tests/sdd.test.mjs
+++ b/plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/tests/sdd.test.mjs
@@ -23,6 +23,9 @@ test("implementation progress scans the complete bounded tasks artifact", (t) =>
     write(join(featureDir, "plan.md"), "# Plan\n", 2);
     const tasks = [
         "# Tasks",
+        "~~~markdown",
+        "- [x] T000 Example only",
+        "~~~",
         "- [x] T001 Complete near the start",
         "padding".repeat(10_000),
         "- [ ] T002 Incomplete after the 64 KiB scan prefix",
@@ -51,6 +54,9 @@ test("clarifications retain stable indices across supported markdown blocks", ()
         "```text",
         "[NEEDS CLARIFICATION: Ignore code?]",
         "```",
+        "   ~~~markdown",
+        "[NEEDS CLARIFICATION: Ignore indented tilde fence?]",
+        "   ~~~",
     ].join("\n");
 
     assert.deepEqual(extractClarifications(markdown), [


### PR DESCRIPTION
## Summary

When a spec or tasks artifact documents the task format inside a code fence, the SDD dashboard counts those example checkboxes as real tasks and shows the example `[NEEDS CLARIFICATION: ...]` markers as unanswered questions. A tasks file with one real task and one fenced example reports two tasks. After this change it reports one.

## Problem

The parser recognised only unindented triple backticks. Examples written in a tilde fence, or in a fence indented by a space or two, leaked through. The bogus clarifications were the worse half: they appeared as questions with no way to resolve them, because nothing in the artifact actually needed answering.

## Solution

Fence state is now tracked across backtick and tilde fences, allowing the up-to-three spaces CommonMark permits on a marker and requiring a closing run at least as long as the opening one. Only lines outside a fence are considered.

Checkboxes indented four or more spaces still count. Those are nested list items, and telling them apart from an indented code block needs the block context only a real CommonMark parser tracks. Counting is the safe side of that ambiguity, since an extra task is visible in the dashboard and a dropped one is not. Both behaviours are pinned by tests.

## Testing Done

<details>
<summary>Raw logs</summary>

```console
$ node --test plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/tests/sdd.test.mjs
ok 1 - implementation progress scans the complete bounded tasks artifact
ok 2 - task counting ignores fenced examples but keeps indented list items
ok 3 - clarifications retain stable indices across supported markdown blocks
ok 4 - dashboard gates setup controls and exposes stage status names
ok 5 - dashboard matches clarification actions by question instead of render position
# tests 5
# pass 5
# fail 0

$ node -e '
const m = await import("./plugins/spec-kit-copilot-sdd/extensions/sdd-canvas/sdd.mjs");
const tasks = "   ~~~markdown\n   - [x] T0\n   ~~~\n- [x] T1";
const q = "   ~~~markdown\n[NEEDS CLARIFICATION: in fence]\n   ~~~\n[NEEDS CLARIFICATION: real]";
console.log("tasks:", m.taskProgress(tasks));
console.log("questions:", m.extractClarifications(q));
'
# origin/main, the fenced example counted:
# tasks: { total: 2, completed: 2 }
# questions: [ { question: "in fence" }, { question: "real" } ]

# this branch, only the real ones:
# tasks: { total: 1, completed: 1 }
# questions: [ { question: "real" } ]
```

</details>
