### PR TITLE
Release Spec Kit wizard 0.1.1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec Kit integrations for GitHub Copilot CLI and the GitHub Copilot App.",
-    "version": "0.18.0"
+    "version": "0.18.1"
   },
   "plugins": [
     {
@@ -35,9 +35,8 @@
     {
       "name": "spec-kit-copilot-wizard",
       "description": "Adds a guided Spec Kit Wizard canvas that drives the full spec-driven development lifecycle via the spec-kit-copilot skills plugin.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "source": "plugins/spec-kit-copilot-wizard"
     }
   ]
 }
-

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) to get star
 | `spec-kit-copilot-assess` | 0.1.0 | Copilot App canvas | Optional visual dashboard for the Spec Kit `assess` extension |
 | `spec-kit-copilot-bugfix` | 0.1.0 | Copilot App canvas | Optional visual dashboard for the Spec Kit `bug` extension |
 | `spec-kit-copilot-sdd` | 0.1.0 | Copilot App canvas | Optional visual dashboard for the core spec-driven development workflow |
-| `spec-kit-copilot-wizard` | 0.1.0 | Copilot App canvas | Optional guided wizard canvas for the full Spec Kit lifecycle |
+| `spec-kit-copilot-wizard` | 0.1.1 | Copilot App canvas | Optional guided wizard canvas for the full Spec Kit lifecycle |
 
 The plugins are independently installable and versioned. Install the core skills,
 the assessment canvas, the bug fix canvas, the spec-driven development canvas, the

--- a/plugins/spec-kit-copilot-wizard/plugin.json
+++ b/plugins/spec-kit-copilot-wizard/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-kit-copilot-wizard",
   "description": "A GitHub Copilot App canvas that provides a guided wizard for the Spec Kit spec-driven development lifecycle.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "GitHub",
     "url": "https://github.com/github/spec-kit-copilot"


### PR DESCRIPTION
## Summary

- bump `spec-kit-copilot-wizard` from `0.1.0` to `0.1.1` in its plugin manifest
- update the marketplace plugin entry and README version table
- bump marketplace metadata from `0.18.0` to `0.18.1` because the catalog changed

Includes the distributed release version for the Spec Kit Wizard fixes merged in #24.

## Validation

- confirmed the wizard manifest, marketplace entry, and README advertise `0.1.1`
- confirmed no unrelated plugin or preset versions changed
- parsed and validated the JSON manifests